### PR TITLE
fix(setup): --mode=rehydrate for CT-rebuild idempotency (#2 P0 A1/A4/A5)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -11,6 +11,40 @@ Run setup steps automatically. Only pause when user action is required (channel 
 
 **UX Note:** Use `AskUserQuestion` for multiple-choice questions only (e.g. "Docker or Apple Container?", "which channels?"). Do NOT use it when free-text input is needed (e.g. phone numbers, tokens, paths) — just ask the question in plain text and wait for the user's reply.
 
+## Pre-flight: Fresh install or rebuild / rehydrate?
+
+Before running any step, determine which scenario you're in — the steps to take and the flags to pass differ.
+
+- **Fresh install** — no prior `.env`, no `groups/*`, no systemd unit, no container image. Run the full flow below (sections 0 through 9).
+- **Rebuild / rehydrate** — the machine or container was destroyed and recreated, but the application state (`.env`, `groups/`, `store/`, `data/`, `logs/`, `~/.config/nanoclaw/mount-allowlist.json`, `~/.claude`, and in the IaC-managed Proxmox case also `/var/lib/docker`) survived on bind mounts / ZFS datasets. Do NOT re-run registration/mount/group steps — they will either no-op or prompt the operator unnecessarily. Use the rehydrate flow below.
+- **Re-run after a partial failure** — same as fresh install for the step that failed; other steps are idempotent except `service` (which kills running processes by default — see below).
+
+Detect rehydrate quickly:
+
+```bash
+# All three of these present → almost certainly rehydrate, not fresh
+test -f .env && test -d groups && test -f ~/.config/nanoclaw/mount-allowlist.json && echo "rehydrate-candidate"
+```
+
+Also: `systemctl --user is-active nanoclaw` returning `active` (or `systemctl is-active nanoclaw` if running as root) means the service is already up — do not run the service step without the rehydrate flags or you will kill the live channel sessions.
+
+### Rehydrate flow (minimal)
+
+Skip sections 0 (git), 2 (environment setup prompts), 2a (timezone), 4 (credentials — already in OneCLI / `.env`), 5 (channels — already merged), 6 (mounts — file already on bind mount). Run only:
+
+1. **Section 1 (bootstrap)** — if `node_modules` is gone from the fresh rootfs, `bash setup.sh` is still needed to reinstall deps.
+2. **Section 3c (container)** — only if the Docker image is missing from `/var/lib/docker`: `npx tsx setup/index.ts --step container -- --runtime docker`. Skip if `docker image inspect nanoclaw-agent:latest` succeeds.
+3. **Section 7 (service) with rehydrate flags** — `npx tsx setup/index.ts --step service -- --mode=rehydrate`. This preserves any hand-edited unit file, skips `pkill` of a running nanoclaw, and skips `systemctl start` if the service is already active. Status block includes `MODE=rehydrate` and `UNIT_PRESERVED=true` when the unit existed.
+4. **Section 8 (verify)** — always safe.
+
+Do NOT run sections 5 (channel skills) or 6 (mounts) unless a specific channel's auth has genuinely been lost. Re-invoking `/add-whatsapp` etc. on rehydrate can re-trigger QR flows against a live session.
+
+Individual flags for partial scenarios (use when `--mode=rehydrate` is too blanket):
+
+- `--preserve-unit` — don't rewrite `/etc/systemd/system/nanoclaw.service` or `~/.config/systemd/user/nanoclaw.service` (protects operator customizations like `OOMScoreAdjust=`, custom `ReadWritePaths=`).
+- `--no-kill` — don't `pkill` running nanoclaw processes (use when running `/setup --step service` to pick up a config change on a live system).
+- `--skip-if-running` — don't `systemctl start` if already `is-active`.
+
 ## 0. Git & Fork Setup
 
 Check the git remote configuration to ensure the user has a fork and upstream is configured.
@@ -273,12 +307,25 @@ If the build fails, read the error output and fix it (usually a missing dependen
 
 ## 6. Mount Allowlist
 
+**Rehydrate check first:** If you've already determined this is a rebuild (pre-flight section above), the file at `~/.config/nanoclaw/mount-allowlist.json` almost certainly already exists on the bind mount. Skip this section entirely — do not re-prompt the operator for mount paths. You can confirm with `test -f ~/.config/nanoclaw/mount-allowlist.json`.
+
 AskUserQuestion: Agent access to external directories?
 
 **No:** `npx tsx setup/index.ts --step mounts -- --empty`
 **Yes:** Collect paths/permissions. `npx tsx setup/index.ts --step mounts -- --json '{"allowedRoots":[...],"blockedPatterns":[],"nonMainReadOnly":true}'`
 
+**If STATUS=skipped in the status block:** The file already exists and `--force` was not passed. That is the correct outcome on rebuilds and on any re-run that should preserve operator choices — do NOT re-prompt and do NOT pass `--force` unless the operator has explicitly said "reset my mount allowlist". Pass `--force` only for:
+
+- The operator said "redo mounts" / "reset mount allowlist" / equivalent.
+- The config file is corrupt (won't parse as JSON) and the operator agreed to start over.
+
+Otherwise leave the existing file untouched and continue.
+
 ## 7. Start Service
+
+**Rehydrate check:** If this is a rebuild / rehydrate (see pre-flight section), run `npx tsx setup/index.ts --step service -- --mode=rehydrate` instead. That preserves any operator-customized unit file, skips `pkill` of a running nanoclaw, and skips `systemctl start` if the service is already active. A successful rehydrate shows `MODE=rehydrate` and (when a unit existed) `UNIT_PRESERVED=true` in the status block. Stop here after verify succeeds.
+
+For a fresh install or a genuine re-install where you want the unit regenerated:
 
 If service already running: unload first.
 - macOS: `launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist`

--- a/setup/service.test.ts
+++ b/setup/service.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
+
+import { parseServiceArgs, writeUnitFileIfNeeded } from './service.js';
 
 /**
  * Tests for service configuration generation.
@@ -163,6 +167,110 @@ describe('systemd unit generation', () => {
     expect(unit).toContain(
       'ExecStart=/usr/bin/node /srv/nanoclaw/dist/index.js',
     );
+  });
+});
+
+describe('parseServiceArgs', () => {
+  it('defaults to full mode with no preservation flags', () => {
+    const flags = parseServiceArgs([]);
+    expect(flags.mode).toBe('full');
+    expect(flags.preserveUnit).toBe(false);
+    expect(flags.noKill).toBe(false);
+    expect(flags.skipIfRunning).toBe(false);
+  });
+
+  it('treats --mode=rehydrate as all three preservation flags', () => {
+    const flags = parseServiceArgs(['--mode=rehydrate']);
+    expect(flags.mode).toBe('rehydrate');
+    expect(flags.preserveUnit).toBe(true);
+    expect(flags.noKill).toBe(true);
+    expect(flags.skipIfRunning).toBe(true);
+  });
+
+  it('accepts space-separated --mode rehydrate form', () => {
+    const flags = parseServiceArgs(['--mode', 'rehydrate']);
+    expect(flags.mode).toBe('rehydrate');
+    expect(flags.preserveUnit).toBe(true);
+  });
+
+  it('honors individual flags without --mode', () => {
+    const flags = parseServiceArgs([
+      '--preserve-unit',
+      '--no-kill',
+      '--skip-if-running',
+    ]);
+    expect(flags.mode).toBe('full');
+    expect(flags.preserveUnit).toBe(true);
+    expect(flags.noKill).toBe(true);
+    expect(flags.skipIfRunning).toBe(true);
+  });
+
+  it('honors a single individual flag (partial rebuild scenario)', () => {
+    const flags = parseServiceArgs(['--no-kill']);
+    expect(flags.mode).toBe('full');
+    expect(flags.preserveUnit).toBe(false);
+    expect(flags.noKill).toBe(true);
+    expect(flags.skipIfRunning).toBe(false);
+  });
+
+  it('ignores unknown --mode values (stays full)', () => {
+    const flags = parseServiceArgs(['--mode=gibberish']);
+    expect(flags.mode).toBe('full');
+    expect(flags.preserveUnit).toBe(false);
+  });
+
+  it('rehydrate and individual flags combine idempotently', () => {
+    const flags = parseServiceArgs(['--mode=rehydrate', '--no-kill']);
+    expect(flags.mode).toBe('rehydrate');
+    expect(flags.noKill).toBe(true);
+    expect(flags.preserveUnit).toBe(true);
+  });
+});
+
+describe('writeUnitFileIfNeeded', () => {
+  function tmpUnitPath(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nanoclaw-unit-'));
+    return path.join(dir, 'nanoclaw.service');
+  }
+
+  it('writes the unit when no file exists (fresh install)', () => {
+    const p = tmpUnitPath();
+    const flags = parseServiceArgs([]);
+    const result = writeUnitFileIfNeeded(p, 'freshly-generated', flags);
+    expect(result.written).toBe(true);
+    expect(result.preservedExisting).toBe(false);
+    expect(fs.readFileSync(p, 'utf8')).toBe('freshly-generated');
+  });
+
+  it('preserves operator customizations in rehydrate mode', () => {
+    const p = tmpUnitPath();
+    fs.writeFileSync(p, '# CUSTOM_MARKER: must survive');
+    const flags = parseServiceArgs(['--mode=rehydrate']);
+    const result = writeUnitFileIfNeeded(p, 'regenerated-would-clobber', flags);
+    expect(result.written).toBe(false);
+    expect(result.preservedExisting).toBe(true);
+    expect(fs.readFileSync(p, 'utf8')).toBe('# CUSTOM_MARKER: must survive');
+  });
+
+  it('overwrites existing unit in full mode (current install behavior)', () => {
+    const p = tmpUnitPath();
+    fs.writeFileSync(p, 'stale-content');
+    const flags = parseServiceArgs([]);
+    const result = writeUnitFileIfNeeded(p, 'regenerated', flags);
+    expect(result.written).toBe(true);
+    expect(result.preservedExisting).toBe(false);
+    expect(fs.readFileSync(p, 'utf8')).toBe('regenerated');
+  });
+
+  it('still writes when --preserve-unit is set but no file exists', () => {
+    // Rebuild into an empty CT: preserve-unit requested, but nothing to preserve.
+    // Must write so the service can actually start.
+    const p = tmpUnitPath();
+    const flags = parseServiceArgs(['--preserve-unit']);
+    const result = writeUnitFileIfNeeded(p, 'must-write', flags);
+    expect(result.written).toBe(true);
+    expect(result.preservedExisting).toBe(false);
+    expect(fs.readFileSync(p, 'utf8')).toBe('must-write');
   });
 });
 

--- a/setup/service.ts
+++ b/setup/service.ts
@@ -20,13 +20,79 @@ import {
 } from './platform.js';
 import { emitStatus } from './status.js';
 
-export async function run(_args: string[]): Promise<void> {
+export interface ServiceFlags {
+  mode: 'full' | 'rehydrate';
+  preserveUnit: boolean;
+  noKill: boolean;
+  skipIfRunning: boolean;
+}
+
+// Rehydrate mode is used when the CT is rebuilt but the application state
+// (unit files, running service, on-disk groups) survives on a bind mount.
+// See issue #2 (Mouriya-Emma/nanoclaw) and homelab-tf#63/#64.
+export function parseServiceArgs(args: string[]): ServiceFlags {
+  let mode: 'full' | 'rehydrate' = 'full';
+  let preserveUnit = false;
+  let noKill = false;
+  let skipIfRunning = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--mode' && args[i + 1]) {
+      const v = args[i + 1];
+      if (v === 'rehydrate' || v === 'full') {
+        mode = v;
+      }
+      i++;
+    } else if (a.startsWith('--mode=')) {
+      const v = a.slice('--mode='.length);
+      if (v === 'rehydrate' || v === 'full') {
+        mode = v;
+      }
+    } else if (a === '--preserve-unit') {
+      preserveUnit = true;
+    } else if (a === '--no-kill') {
+      noKill = true;
+    } else if (a === '--skip-if-running') {
+      skipIfRunning = true;
+    }
+  }
+
+  if (mode === 'rehydrate') {
+    preserveUnit = true;
+    noKill = true;
+    skipIfRunning = true;
+  }
+
+  return { mode, preserveUnit, noKill, skipIfRunning };
+}
+
+// Write a unit/plist file, honoring --preserve-unit semantics.
+// Returns what was done so the caller can emit accurate status.
+export function writeUnitFileIfNeeded(
+  unitPath: string,
+  content: string,
+  flags: ServiceFlags,
+): { written: boolean; preservedExisting: boolean } {
+  const exists = fs.existsSync(unitPath);
+  if (flags.preserveUnit && exists) {
+    return { written: false, preservedExisting: true };
+  }
+  fs.writeFileSync(unitPath, content);
+  return { written: true, preservedExisting: false };
+}
+
+export async function run(args: string[]): Promise<void> {
   const projectRoot = process.cwd();
   const platform = getPlatform();
   const nodePath = getNodePath();
   const homeDir = os.homedir();
+  const flags = parseServiceArgs(args);
 
-  logger.info({ platform, nodePath, projectRoot }, 'Setting up service');
+  logger.info(
+    { platform, nodePath, projectRoot, flags },
+    'Setting up service',
+  );
 
   // Build first
   logger.info('Building TypeScript');
@@ -52,9 +118,9 @@ export async function run(_args: string[]): Promise<void> {
   fs.mkdirSync(path.join(projectRoot, 'logs'), { recursive: true });
 
   if (platform === 'macos') {
-    setupLaunchd(projectRoot, nodePath, homeDir);
+    setupLaunchd(projectRoot, nodePath, homeDir, flags);
   } else if (platform === 'linux') {
-    setupLinux(projectRoot, nodePath, homeDir);
+    setupLinux(projectRoot, nodePath, homeDir, flags);
   } else {
     emitStatus('SETUP_SERVICE', {
       SERVICE_TYPE: 'unknown',
@@ -72,6 +138,7 @@ function setupLaunchd(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
+  flags: ServiceFlags,
 ): void {
   const plistPath = path.join(
     homeDir,
@@ -112,20 +179,40 @@ function setupLaunchd(
 </dict>
 </plist>`;
 
-  fs.writeFileSync(plistPath, plist);
-  logger.info({ plistPath }, 'Wrote launchd plist');
+  const plistResult = writeUnitFileIfNeeded(plistPath, plist, flags);
+  if (plistResult.preservedExisting) {
+    logger.info(
+      { plistPath },
+      'Preserving existing launchd plist (rehydrate mode)',
+    );
+  } else {
+    logger.info({ plistPath }, 'Wrote launchd plist');
+  }
 
+  // Check if already loaded before deciding whether to load
+  let alreadyLoaded = false;
   try {
-    execSync(`launchctl load ${JSON.stringify(plistPath)}`, {
-      stdio: 'ignore',
-    });
-    logger.info('launchctl load succeeded');
+    const output = execSync('launchctl list', { encoding: 'utf-8' });
+    alreadyLoaded = output.includes('com.nanoclaw');
   } catch {
-    logger.warn('launchctl load failed (may already be loaded)');
+    // launchctl list failed — treat as not loaded
+  }
+
+  if (flags.skipIfRunning && alreadyLoaded) {
+    logger.info('launchd service already loaded — skipping load (rehydrate mode)');
+  } else {
+    try {
+      execSync(`launchctl load ${JSON.stringify(plistPath)}`, {
+        stdio: 'ignore',
+      });
+      logger.info('launchctl load succeeded');
+    } catch {
+      logger.warn('launchctl load failed (may already be loaded)');
+    }
   }
 
   // Verify
-  let serviceLoaded = false;
+  let serviceLoaded = alreadyLoaded;
   try {
     const output = execSync('launchctl list', { encoding: 'utf-8' });
     serviceLoaded = output.includes('com.nanoclaw');
@@ -139,6 +226,8 @@ function setupLaunchd(
     PROJECT_PATH: projectRoot,
     PLIST_PATH: plistPath,
     SERVICE_LOADED: serviceLoaded,
+    MODE: flags.mode,
+    PLIST_PRESERVED: plistResult.preservedExisting,
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });
@@ -148,14 +237,15 @@ function setupLinux(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
+  flags: ServiceFlags,
 ): void {
   const serviceManager = getServiceManager();
 
   if (serviceManager === 'systemd') {
-    setupSystemd(projectRoot, nodePath, homeDir);
+    setupSystemd(projectRoot, nodePath, homeDir, flags);
   } else {
     // WSL without systemd or other Linux without systemd
-    setupNohupFallback(projectRoot, nodePath, homeDir);
+    setupNohupFallback(projectRoot, nodePath, homeDir, flags);
   }
 }
 
@@ -205,6 +295,7 @@ function setupSystemd(
   projectRoot: string,
   nodePath: string,
   homeDir: string,
+  flags: ServiceFlags,
 ): void {
   const runningAsRoot = isRoot();
 
@@ -224,7 +315,7 @@ function setupSystemd(
       logger.warn(
         'systemd user session not available — falling back to nohup wrapper',
       );
-      setupNohupFallback(projectRoot, nodePath, homeDir);
+      setupNohupFallback(projectRoot, nodePath, homeDir, flags);
       return;
     }
     const unitDir = path.join(homeDir, '.config', 'systemd', 'user');
@@ -252,8 +343,15 @@ StandardError=append:${projectRoot}/logs/nanoclaw.error.log
 [Install]
 WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
 
-  fs.writeFileSync(unitPath, unit);
-  logger.info({ unitPath }, 'Wrote systemd unit');
+  const unitResult = writeUnitFileIfNeeded(unitPath, unit, flags);
+  if (unitResult.preservedExisting) {
+    logger.info(
+      { unitPath },
+      'Preserving existing systemd unit (rehydrate mode)',
+    );
+  } else {
+    logger.info({ unitPath }, 'Wrote systemd unit');
+  }
 
   // Detect stale docker group before starting (user systemd only)
   const dockerGroupStale = !runningAsRoot && checkDockerGroupStale();
@@ -263,8 +361,14 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     );
   }
 
-  // Kill orphaned nanoclaw processes to avoid channel connection conflicts
-  killOrphanedProcesses(projectRoot);
+  // Kill orphaned nanoclaw processes to avoid channel connection conflicts.
+  // In rehydrate mode, skip — we want to preserve the running service across
+  // a CT rebuild or a follow-up `/setup` run for other steps.
+  if (flags.noKill) {
+    logger.info('Skipping orphan process kill (rehydrate mode)');
+  } else {
+    killOrphanedProcesses(projectRoot);
+  }
 
   // Enable lingering so the user service survives SSH logout.
   // Without linger, systemd terminates all user processes when the last session closes.
@@ -280,7 +384,7 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     }
   }
 
-  // Enable and start
+  // daemon-reload is always safe and needed if unit was written
   try {
     execSync(`${systemctlPrefix} daemon-reload`, { stdio: 'ignore' });
   } catch (err) {
@@ -293,14 +397,27 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     logger.error({ err }, 'systemctl enable failed');
   }
 
+  // Check if already active before starting
+  let alreadyActive = false;
   try {
-    execSync(`${systemctlPrefix} start nanoclaw`, { stdio: 'ignore' });
-  } catch (err) {
-    logger.error({ err }, 'systemctl start failed');
+    execSync(`${systemctlPrefix} is-active nanoclaw`, { stdio: 'ignore' });
+    alreadyActive = true;
+  } catch {
+    // Not active
   }
 
-  // Verify
-  let serviceLoaded = false;
+  if (flags.skipIfRunning && alreadyActive) {
+    logger.info('systemd service already active — skipping start (rehydrate mode)');
+  } else {
+    try {
+      execSync(`${systemctlPrefix} start nanoclaw`, { stdio: 'ignore' });
+    } catch (err) {
+      logger.error({ err }, 'systemctl start failed');
+    }
+  }
+
+  // Verify (re-check; start may have just happened)
+  let serviceLoaded = alreadyActive;
   try {
     execSync(`${systemctlPrefix} is-active nanoclaw`, { stdio: 'ignore' });
     serviceLoaded = true;
@@ -316,6 +433,8 @@ WantedBy=${runningAsRoot ? 'multi-user.target' : 'default.target'}`;
     SERVICE_LOADED: serviceLoaded,
     ...(dockerGroupStale ? { DOCKER_GROUP_STALE: true } : {}),
     LINGER_ENABLED: !runningAsRoot,
+    MODE: flags.mode,
+    UNIT_PRESERVED: unitResult.preservedExisting,
     STATUS: 'success',
     LOG: 'logs/setup.log',
   });


### PR DESCRIPTION
Fixes part of #2 — specifically P0 scope **A1** (`service.ts` no-op on rebuild), **A4** (mount-allowlist re-prompt on rebuild), and adopts the **A5(a)** shape (`--mode=rehydrate` at `setup/index.ts` level rather than a new `/rehydrate` skill).

## Summary

- `setup/service.ts` gains three flags: `--preserve-unit`, `--no-kill`, `--skip-if-running`. `--mode=rehydrate` is sugar for all three.
- `writeUnitFileIfNeeded()` is extracted as a pure, testable helper. The preservation rule is: if `preserveUnit` is set AND a unit file already exists, leave it alone; otherwise write. An empty CT with `--preserve-unit` still gets its unit written (otherwise the service couldn't start).
- `killOrphanedProcesses()` is gated by `--no-kill`. Without this, a follow-up `/setup --step service` to pick up a config change would kill the live channel sessions.
- `systemctl start` / `launchctl load` are gated by `--skip-if-running && is-active` — rebuild against a bind mount often sees the service already brought up by systemd generator before `/setup` gets invoked.
- Status block gets `MODE` and `UNIT_PRESERVED` / `PLIST_PRESERVED`.
- `.claude/skills/setup/SKILL.md` adds a pre-flight section for fresh-install vs rehydrate detection, a rehydrate-minimal flow, updated mount-allowlist handling so Claude Code treats `STATUS=skipped` as the correct outcome (don't pass `--force` unless the operator explicitly asked), and a rehydrate note in section 7.

What's deliberately NOT in this PR: A2 (container image skip-if-present), A3 (ASSISTANT_NAME read-before-write), A6 (`docs/paths.md`), B1/B2/B3 (`/update-nanoclaw` runtime-state-safe). Those are the P1/P2 items from #2 and are independent follow-ups. A5 shape is (a) — `--mode=rehydrate` at index.ts level — no new `/rehydrate` skill.

## Test plan — layered evidence

### Layer 1 — Change preview
- `npm run build` — tsc clean.
- `npx vitest run setup/service.test.ts` — 21/21 pass. New coverage: 7 `parseServiceArgs` tests and 4 `writeUnitFileIfNeeded` tests.
- Full suite: 384/385 pass. The one failure (`src/channels/mattermost.test.ts`) reproduces on `main` without these changes — pre-existing flakiness in mocked fetch responses, unrelated to setup code. Confirmed by `git stash` + checkout-main-only-for-setup-files and re-running the mattermost file alone (same 5 unhandled rejections).

### Layer 2 — On-disk verification
`writeUnitFileIfNeeded` integration tests use `fs.mkdtempSync` for real on-disk verification. The four transitions that matter:

| Scenario | Expected | Asserted |
|----------|----------|----------|
| No file + full mode | write | `written === true`, content matches |
| No file + `--preserve-unit` | still write (empty-CT case) | `written === true` — critical, otherwise service can't start |
| Existing file + `--mode=rehydrate` | preserve, byte-identical | `readFileSync === '# CUSTOM_MARKER: must survive'` |
| Existing file + full mode | overwrite (current behavior kept) | `readFileSync === 'regenerated'` |

These aren't mocked — they write to a real tmp dir, read back, compare exact bytes.

### Layer 3 — Startup / runtime
**Not applicable on this dev machine.** There is no live nanoclaw systemd unit here (`ls ~/.config/systemd/user/nanoclaw.service` → not found, `systemctl --user is-active nanoclaw` → empty). Running `/setup --step service -- --mode=rehydrate` against real systemd wouldn't prove anything meaningful — there's nothing to preserve and nothing to skip-if-running against.

The real runtime verification happens when CT 105 is destroyed and re-created per homelab-tf#63 / #64. At that point the bind-mounted `/root/.config/systemd/user/nanoclaw.service` exists from before the rebuild, and the operator (or Ansible's post-provision hook) runs:

```bash
npx tsx setup/index.ts --step service -- --mode=rehydrate
```

Expected status block: `MODE=rehydrate`, `UNIT_PRESERVED=true`, `SERVICE_LOADED=true`, and `logs/nanoclaw.log` shows no reconnect storm on WhatsApp / Telegram.

### Layer 4 — End-to-end
Same as Layer 3 — the genuine E2E is the CT 105 rebuild. Will be exercised when homelab-tf#63 is executed. This PR ships the code + skill docs that rebuild will exercise; the PR is the contract to be validated at that moment.

## Analysis

The three gates (`preserveUnit`, `noKill`, `skipIfRunning`) are the minimal A1 fix. They can be set individually or all at once via `--mode=rehydrate`. Exposing individuals keeps the \"pick up a config change without killing the live service\" use case (`--no-kill` alone) accessible without adopting the full rehydrate semantics.

On A5 shape — the flag at `setup/index.ts` (actually parsed in `service.ts` step-args) is cheaper to maintain than a parallel `/rehydrate` skill: rehydrate semantics are already largely per-step, and putting them in a separate skill would duplicate the flag parsing and the mode dispatch in every step that cares about it. If a `/rehydrate` skill turns out useful later, it can just wrap the flags.

The unit-test-only layer-2 evidence is an honest gap vs. the layered-testing rule. It's called out explicitly rather than hidden. The real validation event is the first CT 105 rebuild; until then, the unit tests plus the SKILL.md diff are the contract. If rehydrate fails at that moment, a follow-up PR fixes it and re-validates — the same test harness is already in place.

What would cause this to be wrong and get missed here: if `systemctl --user is-active` returns something unexpected (wrong exit code on systemd <245 or on root systemd). Layer 3 on the real CT is what catches that. Layer 1/2 only cover the decision logic, not the systemd-side semantics.