### PR TITLE
feat(cicd): Pattern A deploy workflow (vctcn-runner to VM 106)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,104 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'container/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+# Pattern A (per Mouriya-Emma/local-cicd-demo §Deployment patterns):
+# build on a github-hosted runner, deploy on the netbird-mesh runner.
+# The deploy step rsyncs dist/ + container/ to deploy@nanoclaw.mouriya.lan
+# then `sudo systemctl restart nanoclaw` and a smoke check.
+#
+# Secrets needed (configured in this repo's settings):
+#   DEPLOY_SSH_KEY   - private ed25519 key whose public counterpart is
+#                      authorized for the deploy user on VM 106 (managed by
+#                      homelab-tf _shared/ansible/secrets.yml :
+#                      nanoclaw_deploy_ssh_pubkey).
+
+# Only one deploy can be in flight at a time. Newer pushes wait for the
+# active deploy to finish; the queue collapses if multiple lands during
+# a long deploy.
+concurrency:
+  group: nanoclaw-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository == 'Mouriya-Emma/nanoclaw'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: container
+          path: container/
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: [self-hosted, linux, vctcn]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: container
+          path: container/
+
+      - name: Stage SSH key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          TARGET: nanoclaw.mouriya.lan
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          # Trust-on-first-use is acceptable here: target is reachable
+          # only via netbird, and ssh-keyscan runs from the netbird side.
+          ssh-keyscan -H "$TARGET" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Rsync dist + container to /opt/nanoclaw
+        env:
+          TARGET: nanoclaw.mouriya.lan
+        run: |
+          rsync -az --delete \
+            -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
+            dist/ "deploy@${TARGET}:/opt/nanoclaw/dist/"
+          rsync -az --delete \
+            -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
+            container/ "deploy@${TARGET}:/opt/nanoclaw/container/"
+
+      - name: Restart + smoke
+        env:
+          TARGET: nanoclaw.mouriya.lan
+        run: |
+          ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes "deploy@${TARGET}" \
+            'sudo systemctl restart nanoclaw && sleep 3 && sudo systemctl is-active nanoclaw'
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/id_deploy


### PR DESCRIPTION
Closes #4.

Pattern A deploy workflow per `Mouriya-Emma/local-cicd-demo` README §Deployment patterns. Build on `ubuntu-latest`, deploy on `vctcn-nanoclaw` (a netbird-mesh peer that can reach `nanoclaw.mouriya.lan` over the overlay).

This is the third of three PRs:

| PR | Status | Role |
| --- | --- | --- |
| `Mouriya-Emma/homelab-tf#120` | Merged | VM 106 scaffold (deploy user, sudoers, systemd unit, bao-backed launch wrapper) |
| `Mouriya-Emma/pve-vctcn#26` | Merged | `vctcn-nanoclaw` runner registered against this repo |
| **This PR** | — | Workflow that ties them together |

## What lands

Single new file: `.github/workflows/deploy.yml`.

* Triggers: `push` on `main` matching `paths:` (src, container, lockfiles, tsconfig, the workflow itself), or manual `workflow_dispatch`.
* `if: github.repository == 'Mouriya-Emma/nanoclaw'` — defensive gate, same shape as the existing `bump-version.yml`. Doesn't fire on forks or if upstream rebases this through.
* Build on `ubuntu-latest`: `npm ci && npm run build` → upload `dist/` + `container/` artifacts.
* Deploy on `[self-hosted, linux, vctcn]`: download artifacts → stage `DEPLOY_SSH_KEY` → rsync to `deploy@nanoclaw.mouriya.lan:/opt/nanoclaw/{dist,container}/` → `sudo systemctl restart nanoclaw && systemctl is-active nanoclaw`.
* `concurrency: nanoclaw-deploy, cancel-in-progress: false` — two simultaneous pushes serialise instead of racing for `dist/`.

## Layer 1 — TF / infra

Not applicable. Only operator-supplied repo state changes (this PR).

## Layer 2 — Workflow lint / runner labels

`runs-on: [self-hosted, linux, vctcn]` requires all three labels. The runner `vctcn-nanoclaw` (registered by `Mouriya-Emma/pve-vctcn#26`) advertises `self-hosted, Linux, X64, vctcn, netbird` — superset, matches. No other runner in this repo's pool has the `vctcn` label, so no cross-repo accidental scheduling.

## Layer 3 — runner-side script trace

The deploy step does, in order:

1. Download artifacts from build job — standard GHA primitive.
2. Stage `~/.ssh/id_deploy` from `secrets.DEPLOY_SSH_KEY` (already set on this repo: `gh secret list -R Mouriya-Emma/nanoclaw` shows `DEPLOY_SSH_KEY 2026-04-26T16:27:47Z`).
3. `ssh-keyscan -H nanoclaw.mouriya.lan` populates `known_hosts` for the duration of the job.
4. Two `rsync -az --delete` invocations push `dist/` + `container/` to `deploy@nanoclaw.mouriya.lan:/opt/nanoclaw/{dist,container}/`.
5. `ssh deploy@... sudo systemctl restart nanoclaw && sleep 3 && sudo systemctl is-active nanoclaw` — the sudoers fragment from `homelab-tf#120` allows exactly these three subcommands (restart, is-active, status); nothing else.
6. `if: always()` cleanup removes the privkey from the runner.

## Layer 4 — runtime expectation

After merge + first eligible push:

* Build job runs on a clean `ubuntu-latest`. `npm run build` produces `dist/`. Artifacts upload.
* Deploy job runs on `vctcn-nanoclaw`. Artifacts download into the runner's workspace. SSH key staged. Two rsyncs land.
* `sudo systemctl restart nanoclaw` triggers the launch wrapper which fetches secrets from `secret/nanoclaw/runtime` in OpenBao, materialises `/opt/nanoclaw/.env`, and execs `node dist/index.js`. `systemctl is-active nanoclaw` returns `active` once the orchestrator boots.
* Post-deploy: nanoclaw's WebSocket connects to vctcn mattermost (`http://vctcn-app1.mouriya.lan:8065`) as the bot user `nanoclaw` (id `q9ncub6n9fr1p837uexpmrqeaw`, role `system_user`). DM-ing the bot or @-mentioning it in a channel triggers the orchestrator path.

## Final analysis

A/B/C/D verified at design level: workflow shape matches the local-cicd-demo template, runner labels match `runs-on`, sudoers fragment covers the exact systemctl invocations, GHA secret is in place. The only thing left is the actual first run — that fires automatically post-merge via the `paths:` overlap (next src/container change) or manually via `workflow_dispatch`. PR review-ready.

via [HAPI](https://hapi.run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)