### PR TITLE
fix(mattermost): don't strip trigger pattern before delivering message

### DIFF
--- a/src/channels/mattermost.ts
+++ b/src/channels/mattermost.ts
@@ -1,6 +1,5 @@
 import WebSocket from 'ws';
 
-import { TRIGGER_PATTERN } from '../config.js';
 import { deleteUserToken, getUserToken, setUserToken } from '../db.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
@@ -349,20 +348,21 @@ export class MattermostChannel implements Channel {
       return;
     }
 
-    // Check trigger requirement
-    let content = post.message;
-    if (group.requiresTrigger !== false && !group.isMain) {
-      if (!TRIGGER_PATTERN.test(content.trim())) return;
-      content = content.replace(TRIGGER_PATTERN, '').trim();
-    }
-
-    // Deliver message
+    // Deliver every message to onMessage with content unchanged. The
+    // trigger filter (when `group.requiresTrigger`) is applied by
+    // index.ts's message loop before agent dispatch — re-checking it
+    // here AND stripping the trigger broke the loop's regex match
+    // (`^@Andy\b` won't match an already-stripped message), which is
+    // why `mm-message-flow.test.ts` and any non-main + requiresTrigger
+    // group used to silently drop trigger messages. Telegram channel
+    // already takes this approach (prepend trigger when bot @mentioned;
+    // never strip), so message-loop semantics work uniformly.
     this.opts.onMessage(chatJid, {
       id: post.id,
       chat_jid: chatJid,
       sender: post.user_id,
       sender_name: senderName,
-      content,
+      content: post.message,
       timestamp,
       is_from_me: false,
     });


### PR DESCRIPTION
## TL;DR

`MattermostChannel.handlePosted` was stripping `@Andy` from `content` before calling `onMessage`, then `index.ts`'s message loop re-checks the trigger on the stored message — and the regex `^@Andy\b` never matches a stripped message, so non-main + requiresTrigger groups silently dropped every trigger message. One-line cause, one-line fix; revealed by the bundled vitest e2e suite (`npm run test:e2e:mm`).

## Reproduction

Set up a Mattermost channel registered with `is_main=0, requires_trigger=1`, send `@Andy say hello`. Before this PR: bot's WS handler logs `Mattermost message received` but message loop never logs `Processing messages` — the message is in `messages` table but with content `say hello` (trigger stripped), so `triggerPattern.test(m.content.trim())` returns false, message loop continues without dispatch. After this PR: dispatch fires within 1-2 poll intervals.

## Why Telegram doesn't have this

`src/channels/telegram.ts:421-423` does the opposite — it *prepends* the trigger when the bot is `@mentioned` without one. So message-loop semantics are uniform: every channel hands `onMessage` content that starts with the trigger, and the message loop is the single source of trigger filtering. This PR brings Mattermost in line.

## Evidence — nanoclaw's own e2e suite

Ran `npm run test:e2e:mm` (commands + message-flow + coding + ipc-tools + session + admin) twice against vctcn mattermost (`http://vctcn-app1.mouriya.lan:8065`) with the deployed bot from #12/#13:

| Project | Before fix | After fix |
| --- | ---: | ---: |
| `mm-commands` | 12/12 ✓ | 12/12 ✓ |
| `mm-message-flow` | 0/2 (timeout 180s) | **2/2 ✓** (avg 8.5s) |
| `mm-coding` | 0/4 (skipped, prereq fail) | **4/4 ✓** |
| `mm-ipc-tools` | 0/5 (skipped, prereq fail) | **5/5 ✓** |
| `mm-session` | 0/1 (timeout 180s) | **1/1 ✓** (29.5s) |
| `mm-admin` | 0/12 | **3/12 ✓**, 9 fail (separate root cause — see below) |
| **Total** | 12/36 (33%) | **27/36 (75%)** in 9m59s |

Net gain from this one-line fix: 15 additional tests pass.

### mm-message-flow (before/after)

```
BEFORE
  × trigger message gets agent reply        182027ms (Timed out waiting for bot reply (180000ms))
  × follow-up message reuses container      122019ms

AFTER
  ✓ trigger message gets agent reply         9386ms
  ✓ follow-up message reuses container       7751ms
```

### mm-coding (now passing — bash + filesystem in agent container)

```
✓ bash: executes command                     8136ms
✓ bash: can access workspace                 7385ms
✓ file: write + read roundtrip              15771ms
✓ file: cannot write outside workspace      10283ms
```

### mm-session (state survives container restart)

```
✓ remembers across container restarts       29536ms
```

`/clear` → `@Andy remember "mm-elephant-purple-42-claude-sdk"` → bot confirms → `/stop` → `@Andy what was the code word?` → bot replies `The code word you asked me to remember is: mm-elephant-purple-42-claude-sdk`. Visual proof:

![14-e2e-channel-bottom.png](https://github.com/Mouriya-Emma/nanoclaw/blob/3c9f6f8374d2081aa3905a6bae60b72d2d99e35e/14-e2e-channel-bottom.png?raw=true)

### mm-ipc-tools (host IPC paths)

```
✓ send_message     10017ms
✓ schedule_task    14546ms
✓ list_tasks       10302ms
✓ cancel_task      18229ms
✓ request_tool     10916ms
```

## Out-of-scope (mm-admin's 9 remaining failures)

These are NOT fixed by this PR; they are nanoclaw's `mm-admin` skill having networking + slash-command issues that surface only when the agent container tries to call Mattermost's HTTP API from inside docker. Verbatim from the agent's own attempts in the e2e channel:

```
22:09 bot Failed to execute `/mm-admin create-channel --name e2e-admin-... -- ...
25:25 bot Failed to execute `/channel create --team_name=main --name=e2e-admin-...
26:54 bot I've done extensive investigation and hit a fundamental networking limitation. ...
27:09 bot I'm unable to reach the Mattermost API from this container — the same networking limitation ...
```

Three of the twelve admin tests still pass (`searches messages`, `lists users`, `creates a DM and sends a message`) which proves the agent path is alive — only the channel-creation/management subset hits the wall. Will open a separate issue tracking the `mm-admin` skill fix.

## Layer breakdown for this PR specifically

* **Layer 1 — TF**: not applicable.
* **Layer 2 — code**: 1 file changed, 10 lines added / 10 removed (the import + the trigger-strip block).
* **Layer 3 — service**: deployed to VM 106, restarted, journal showed `groupCount: 2` (existing main DM group + the e2e channel group), bot reauthenticated cleanly.
* **Layer 4 — runtime**: 27/36 e2e tests pass against the deployed binary; the 9 still failing are out-of-scope mm-admin issues with verbatim agent self-reports identifying networking, not the trigger path.

via [HAPI](https://hapi.run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)