### PR TITLE
fix(container): point agent's resolver at netbird wt0 IP

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -27,6 +27,7 @@ import {
   CONTAINER_HOST_GATEWAY,
   CONTAINER_RUNTIME_BIN,
   hostGatewayArgs,
+  netbirdDnsArgs,
   readonlyMountArgs,
   stopContainer,
 } from './container-runtime.js';
@@ -382,6 +383,12 @@ function buildContainerArgs(
 
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
+
+  // If the host is on a netbird mesh, point the agent at the netbird
+  // daemon's DNS (listening on the host's wt0 IP) so mesh-private
+  // domains like `*.mouriya.lan` resolve from inside the container.
+  // No-op on hosts without wt0. See container-runtime.netbirdDnsArgs.
+  args.push(...netbirdDnsArgs());
 
   // Prepend host-exec stubs to PATH so agents can call proxied commands directly
   args.push(

--- a/src/container-runtime.ts
+++ b/src/container-runtime.ts
@@ -49,6 +49,31 @@ export function hostGatewayArgs(): string[] {
   return [];
 }
 
+/**
+ * If a netbird mesh interface (`wt0`) is up, return `--dns=<wt0-ip>` so
+ * the agent container can resolve mesh-private domains (e.g. `*.mouriya.lan`).
+ *
+ * Why this approach over bind-mounting `/etc/resolv.conf`:
+ * the host is typically running systemd-resolved, whose `resolv.conf` points
+ * at the loopback stub `127.0.0.53`. Bind-mounting that file into a container
+ * is a null op — `127.0.0.53` inside the container's network namespace has
+ * nothing listening, so DNS just hangs. The netbird daemon itself listens
+ * on the host's `wt0` IP (port 53) and is reachable from a docker bridge
+ * container as a regular peer IP.
+ *
+ * Returns `[]` on non-Linux hosts or when `wt0` isn't present, so non-mesh
+ * environments fall back to docker's default resolver.
+ */
+export function netbirdDnsArgs(): string[] {
+  if (os.platform() !== 'linux') return [];
+  const ifaces = os.networkInterfaces();
+  const wt0 = ifaces['wt0'];
+  if (!wt0) return [];
+  const ipv4 = wt0.find((a) => a.family === 'IPv4');
+  if (!ipv4) return [];
+  return ['--dns', ipv4.address];
+}
+
 /** Returns CLI args for a readonly bind mount. */
 export function readonlyMountArgs(
   hostPath: string,


### PR DESCRIPTION
Closes #15.

## Root cause

The host runs systemd-resolved, so `/etc/resolv.conf` is a symlink to a stub pointing at `127.0.0.53`. Bind-mounting that file into a container is a no-op: inside the container's network namespace nothing listens on `127.0.0.53`, so DNS just hangs. The agent therefore can't resolve `*.mouriya.lan` and `mm-admin` loops on "Mattermost API hostname is not resolvable".

The netbird daemon itself listens on the host's `wt0` IP at port 53 and is reachable from a docker-bridge container as a regular peer IP. The fix: read the wt0 IPv4 from `os.networkInterfaces()` at spawn time and pass `--dns=<wt0-ip>` to docker. Returns no extra args on non-Linux hosts or when wt0 isn't present, so non-mesh installs fall back to docker's default resolver (no behaviour change).

## Reproducer (pre-fix)

```
$ docker run --rm alpine sh -c "apk add bind-tools >/dev/null && dig +short +time=3 +tries=1 @192.168.1.22 vctcn-app1.mouriya.lan A"
(empty — LAN DNS unreachable from docker bridge)

$ docker run --rm alpine sh -c "apk add bind-tools >/dev/null && dig +short +time=3 +tries=1 @100.85.157.186 vctcn-app1.mouriya.lan A"
100.85.123.224
```

`100.85.157.186` is this host's wt0 IPv4 (netbird daemon listens there); LAN-side DNS at `192.168.1.22` is not routable from `docker0` so that path is dead.

## Layer 4 — e2e suite delta

`npm run test:e2e:mm` against vctcn mattermost, side-by-side:

| Project | After #14 | After this PR |
| --- | ---: | ---: |
| `mm-commands` | 12/12 ✓ | 12/12 ✓ |
| `mm-message-flow` | 2/2 ✓ | 2/2 ✓ |
| `mm-coding` | 4/4 ✓ | 4/4 ✓ |
| `mm-ipc-tools` | 5/5 ✓ | 5/5 ✓ |
| `mm-session` | 1/1 ✓ | 1/1 ✓ |
| `mm-admin` | **3/12** | **9/12** |
| **Total** | 27/36 | **33/36** in 6m16s |

### mm-admin before/after this PR

```
BEFORE
  × creates a public channel             32784ms (timeout, agent: "DNS resolution failure")
  × sets channel header and purpose       2004ms (depends on previous)
  × lists channels and finds the channel 122103ms (timeout)
  × posts a message to another channel    72389ms (timeout)
  × pins a message                         2188ms (depends on previous)
  × adds a reaction to a post              2181ms (depends on previous)
  ✓ searches messages                     84267ms
  ✓ lists users                           14625ms
  ✓ creates a DM and sends a message      10002ms
  × archives a channel                    11590ms
  × restores an archived channel          10417ms
  × creates an incoming webhook            9577ms

AFTER
  ✓ creates a public channel              12416ms
  ✓ sets channel header and purpose        9950ms
  ✓ lists channels and finds the channel  13428ms
  ✓ posts a message to another channel    12163ms
  × pins a message                        16082ms (assertion: pinned still false)
  ✓ adds a reaction to a post             12692ms
  ✓ searches messages                     14073ms
  ✓ lists users                           11857ms
  ✓ creates a DM and sends a message      12698ms
  ✓ archives a channel                     9257ms
  × restores an archived channel          11505ms (assertion: delete_at != 0)
  × creates an incoming webhook           15006ms (hook absent from list)
```

The 3 still-failing tests are all assertion failures on the post-action state, not network/timeout — they're skill-implementation issues (the agent calls the Mattermost API but the operation doesn't yield the expected post-state). Will open a focused follow-up issue for those if the operator considers them in-scope; nothing about them is in the container-DNS path this PR touches.

## Layer 1-3

* Layer 1 — TF: not applicable.
* Layer 2 — code: 2 files changed, +32 lines. New helper `netbirdDnsArgs()` in `container-runtime.ts`; one call site in `container-runner.ts` replacing the no-op resolv.conf bind-mount.
* Layer 3 — service: `npm run build` + rsync dist + `systemctl restart nanoclaw` — service active, journal clean, agent containers spawned during the e2e run all carried `--dns 100.85.157.186`. Verified via `docker inspect <agent-container>` showing `HostConfig.Dns: ["100.85.157.186"]`.

via [HAPI](https://hapi.run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)