### PR TITLE
ci: rewrite deploy.yml for v2.0.54 pnpm baseline

### DIFF
--- a/.coder-loop/workflow.md
+++ b/.coder-loop/workflow.md
@@ -66,7 +66,7 @@ Closes #N.
 
 ## Layer 4 — End-to-end behavior
 
-<E2E evidence. NanoClaw has `e2e/` suites covering Telegram (gramjs), Mattermost (WebSocket+REST), pi-mono OAuth, host-exec. If the change touches channels / runtime / scheduler, run the relevant `npm run test:e2e:*` slice and quote the result. E2E is NOT in CI — operator runs it manually with a live `192.168.1.41` Mattermost + valid `data/pi-auth.json` + `E2E_TELEGRAM_SESSION`. If the env is unavailable, document the gap explicitly rather than waiving.>
+<E2E evidence. NanoClaw has `e2e/` suites covering Telegram (gramjs), Mattermost (WebSocket+REST), pi-mono OAuth, host-exec. If the change touches channels / runtime / scheduler, run the relevant `pnpm run test:e2e:*` slice and quote the result. E2E is NOT in CI — operator runs it manually with a live `192.168.1.41` Mattermost + valid `data/pi-auth.json` + `E2E_TELEGRAM_SESSION`. If the env is unavailable, document the gap explicitly rather than waiving.>
 
 ## Analysis
 
@@ -79,20 +79,20 @@ Drop layers your specific issue genuinely doesn't need (e.g. Layer 4 for a pure 
 
 Per `package.json` and `.github/workflows/ci.yml`:
 
-- Format check: `npm run format:check` (CI gate)
-- Typecheck: `npx tsc --noEmit` (CI gate)
-- Unit tests: `npx vitest run` (CI gate)
-- Build: `npm run build`
-- E2E (manual only, not in CI): `npm run test:e2e:*` slices
+- Format check: `pnpm run format:check` (CI gate)
+- Typecheck: `pnpm exec tsc --noEmit` (CI gate)
+- Unit tests: `pnpm exec vitest run` (CI gate)
+- Build: `pnpm run build`
+- E2E (manual only, not in CI): `pnpm run test:e2e:*` slices
 
-After the v2 baseline migration lands, switch all of the above from `npm` to `pnpm` (v2 upstream uses `pnpm@10.33.0`). Update this section in the same PR that lands the migration.
+The v2.0.54 baseline pins `pnpm@10.33.0` (`package.json` `packageManager`). Local dev install: `pnpm install --frozen-lockfile`.
 
 ## CI-parity evidence
 
 Every PR must state:
 
 - whether `.github/workflows/ci.yml` ran on the PR (visible via `gh pr checks <pr>`);
-- the local CI-parity command actually run (the four-step sequence: `npm ci && npm run format:check && npx tsc --noEmit && npx vitest run`);
+- the local CI-parity command actually run (the four-step sequence: `pnpm install --frozen-lockfile && pnpm run format:check && pnpm exec tsc --noEmit && pnpm exec vitest run`);
 - runner architecture (note: CI is `ubuntu-latest` x86_64; local dev is likely macOS arm64 — `better-sqlite3` rebuild can diverge);
 - exit status of each step;
 - concise log excerpt or log path under `.coder-loop/runtime/evidence/`.
@@ -104,7 +104,7 @@ Remote GitHub `ci.yml` checks are mergeability signals. They do not replace iter
 NanoClaw is a backend / CLI service, not a UI project. Layer 4 evidence is integration testing, not browser screenshots.
 
 For changes touching channels (mattermost/telegram), runtime (claude/pi-mono), scheduler, IPC, or session lifecycle:
-- Run the relevant `npm run test:e2e:*` slice against the operator's live env.
+- Run the relevant `pnpm run test:e2e:*` slice against the operator's live env.
 - Quote the test output (pass/fail counts) in Layer 4.
 - If the live env is unavailable (no `192.168.1.41` reachable, no valid `E2E_TELEGRAM_SESSION`, no `data/pi-auth.json`), document the gap in Layer 4 and block for operator review rather than waiving silently.
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
       - 'container/**'
       - 'scripts/**'
       - 'package.json'
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
       - 'tsconfig.json'
       - '.github/workflows/deploy.yml'
   workflow_dispatch:
@@ -37,12 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-      - run: npm ci --no-audit --no-fund
-      - run: npm run build
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -60,17 +61,17 @@ jobs:
           name: scripts
           path: scripts/
           retention-days: 1
-      # Ship the manifest pair too so the deploy step can install runtime
-      # deps on the target (`npm ci --omit=dev`). Compiling native modules
-      # against the build runner's glibc and shipping node_modules works
-      # for prebuilt packages but breaks for anything that needs to
-      # compile, so we trade slower deploy for reliability.
+      # Ship the manifest pair so the deploy step can install runtime deps on
+      # the target via `pnpm install --frozen-lockfile --prod`. Compiling
+      # native modules against the build runner's glibc and shipping
+      # node_modules works for prebuilt packages but breaks for anything
+      # that needs to compile, so we trade slower deploy for reliability.
       - uses: actions/upload-artifact@v4
         with:
           name: manifest
           path: |
             package.json
-            package-lock.json
+            pnpm-lock.yaml
           retention-days: 1
 
   deploy:
@@ -135,7 +136,7 @@ jobs:
             scripts/ "deploy@${TARGET}:/opt/nanoclaw/scripts/"
           rsync -az \
             -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
-            package.json package-lock.json \
+            package.json pnpm-lock.yaml \
             "deploy@${TARGET}:/opt/nanoclaw/"
 
       - name: Install runtime deps on target
@@ -143,13 +144,13 @@ jobs:
           TARGET: nanoclaw.mouriya.lan
         run: |
           # `--ignore-scripts` skips the `prepare: husky` hook (dev tool
-          # not installed in --omit=dev), but it ALSO skips
-          # better-sqlite3's install hook that downloads/builds the
-          # native .node binding — so we explicitly `npm rebuild` it
-          # afterwards. (Verified: without rebuild, service crashes at
-          # boot with `Could not locate the bindings file`.)
+          # not installed in --prod), but it ALSO skips better-sqlite3's
+          # install hook that downloads/builds the native .node binding —
+          # so we explicitly `pnpm rebuild` it afterwards. (Verified
+          # against v1 npm path: without rebuild, service crashes at boot
+          # with `Could not locate the bindings file`.)
           ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes "deploy@${TARGET}" \
-            'cd /opt/nanoclaw && npm ci --omit=dev --ignore-scripts --no-audit --no-fund && npm rebuild better-sqlite3'
+            'cd /opt/nanoclaw && pnpm install --frozen-lockfile --prod --ignore-scripts && pnpm rebuild better-sqlite3'
 
       - name: Build agent container image on target (uses Docker layer cache)
         env:


### PR DESCRIPTION
Closes #81.

## Summary

Switch `.github/workflows/deploy.yml` from npm to pnpm@10.33.0 to match the v2.0.54 baseline (cutover commit `084ded4`); the v2 repo only ships `pnpm-lock.yaml`, so the existing `setup-node@v4 cache: npm` step was hard-failing every deploy after the cutover. Also align `.coder-loop/workflow.md` Verification commands and the CI-parity four-step sequence to pnpm, per the workflow's own "switch to pnpm in the same PR that lands the migration" directive.

## Layer 1 — Change preview

Only two files change. `git diff --stat HEAD~1`:

```
 .coder-loop/workflow.md      | 16 ++++++++--------
 .github/workflows/deploy.yml | 35 ++++++++++++++++++-----------------
 2 files changed, 27 insertions(+), 26 deletions(-)
```

Full patch saved at `.coder-loop/runtime/evidence/issue-81/feature-diff.patch` (133 lines).

Key shape changes in `deploy.yml`:

- `paths:` trigger — `package-lock.json` → `pnpm-lock.yaml`
- build job — add `pnpm/action-setup@v4`, `setup-node` `cache: pnpm`, `pnpm install --frozen-lockfile`, `pnpm run build`
- manifest artifact — uploads `package.json` + `pnpm-lock.yaml` (no `package-lock.json`)
- deploy job rsync — ships `package.json pnpm-lock.yaml` to `/opt/nanoclaw/`
- target install — `pnpm install --frozen-lockfile --prod --ignore-scripts && pnpm rebuild better-sqlite3` (exactly the command in #81 acceptance row 2)

`workflow.md` Verification commands + CI-parity 4-step + Layer 4 E2E references all swap `npm`/`npx` → `pnpm`/`pnpm exec`/`pnpm run`. No remaining bare `npm` references in the file:

```
$ grep -n '\bnpm\b' .coder-loop/workflow.md
(no output)
```

Analysis: change is mechanical and small. Pattern A (build on ubuntu-latest, deploy on netbird mesh runner), the `concurrency: nanoclaw-deploy` lock, `DEPLOY_SSH_KEY` secret name, target host, systemd restart + 30s smoke check, and exec-bit-restore step are all preserved by-construction; the diff has no churn in those blocks.

## Layer 2 — Landing checks

Architecture: macOS arm64 (`uname -m` → `arm64`); CI runs on `ubuntu-latest` x86_64. better-sqlite3 native binding may differ between platforms — checks below pass locally; CI re-validates on x86_64.

Local CI-parity sequence (per the newly-updated workflow.md):

| # | Command | Exit | Evidence |
|---|---|---|---|
| 1 | `pnpm install --frozen-lockfile` | 0 | Already up to date / Lockfile is up to date |
| 2 | `pnpm run format:check` | 0 | `All matched files use Prettier code style!` |
| 3 | `pnpm exec tsc --noEmit` (host) | 0 | clean stdout |
| 4 | `pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit` (after `bun install --frozen-lockfile` in `container/agent-runner/`) | 0 | clean stdout |
| 5 | `pnpm exec vitest run` (host) | 0 | `Test Files 29 passed (29) / Tests 318 passed (318)` |
| 6 | `cd container/agent-runner && bun test` | 0 | `91 pass / 0 fail / 201 expect() calls / 8 files` |
| 7 | `pnpm run build` | 0 | tsc completes clean |

Log artifacts:

- `.coder-loop/runtime/evidence/issue-81/format-check.log`
- `.coder-loop/runtime/evidence/issue-81/typecheck-host.log`
- `.coder-loop/runtime/evidence/issue-81/typecheck-container.log`
- `.coder-loop/runtime/evidence/issue-81/vitest-host.log`
- `.coder-loop/runtime/evidence/issue-81/bun-test-container.log`
- `.coder-loop/runtime/evidence/issue-81/build.log`
- `.coder-loop/runtime/evidence/issue-81/acceptance-checks.log`
- `.coder-loop/runtime/evidence/issue-81/feature-diff.patch`

CI status: `.github/workflows/ci.yml` will run on this PR (pull_request to main) and exercise the same pnpm/bun chain on x86_64. `gh pr checks` to be confirmed after open.

Trunk-patches: this PR touches `.github/workflows/deploy.yml`, which is a fork-only file (not from upstream — upstream `qwibitai/nanoclaw` has no deploy.yml), and `.coder-loop/workflow.md` (fork-only). No `src/fork-features/trunk-patches.md` entry required.

Analysis: all CI gates pass locally on the same commit that's pushed. The only architecture-sensitive piece (better-sqlite3) is exercised by the host test suite (29 files / 318 tests including db migrations).

## Layer 3 — Startup / runtime ordering

Acceptance criteria from #81, verified row-by-row:

| # | Check | Result |
|---|---|---|
| 1 | manifest artifact contains `pnpm-lock.yaml`, not `package-lock.json` | ✓ `deploy.yml` L70–74 — `upload-artifact manifest` path is `package.json` + `pnpm-lock.yaml` only |
| 2 | target install exactly `pnpm install --frozen-lockfile --prod --ignore-scripts && pnpm rebuild better-sqlite3` | ✓ `deploy.yml` L153 — string match |
| 4 | deploy job does not duplicate `useradd` / `systemctl daemon-reload` / `/etc/sudoers.d` | ✓ `grep -nE 'useradd\|systemctl daemon-reload\|/etc/sudoers' .github/workflows/deploy.yml` → no matches |
| 5 | systemd unit unchanged because start entry is still `node dist/index.js` | ✓ `jq -r '.scripts.start' package.json` → `node dist/index.js` |

Row 3 (`systemctl is-active` returns `active` within 30s) and the run-side row 1/2 log-search checks can only be observed on a real workflow run; the smoke-check block at `deploy.yml` L173–181 is unchanged from the v1 version (15× 2s polls, fail after 30s with `systemctl status` dump), so behavior is identical to the previously-validated v1 deploys aside from the pnpm install replacing npm. End-to-end run will execute after PR merge to main (or via `workflow_dispatch`).

Startup ordering on VM 106: per the smart handler in homelab-tf nanoclaw role, VM 106 is currently `inactive / enabled` (verified at homelab-tf#238 closure). First post-merge deploy → rsync → `pnpm install --prod` → `container/build.sh` → `systemctl restart nanoclaw` → service must reach `active` within 30s. The launch wrapper / systemd unit aren't touched.

Analysis: end-to-end deploy-run validation is gated on this PR merging because the workflow only runs on push to main (or manual dispatch from this branch — the if-guard `github.repository == 'Mouriya-Emma/nanoclaw'` allows that). Risk: pnpm cache key on `setup-node@v4` with `cache: pnpm` requires the lockfile to be present at checkout — it is.

## Layer 4 — End-to-end behavior

Layer 4 is **not applicable as a runtime E2E slice** for this PR because the diff only touches:

- `.github/workflows/deploy.yml` — CI/CD definition file consumed by GitHub Actions, not by the running NanoClaw service
- `.coder-loop/workflow.md` — loop policy doc consumed by coder-loop agents, not by the running service

Neither file is loaded by `src/index.ts`, the message loop, channels, scheduler, IPC, or session lifecycle. `npm run test:e2e:*` slices (Mattermost/Telegram/pi-mono/host-exec) do not exercise GitHub Actions workflows; running them would not produce signal for this change.

The true end-to-end signal is the workflow run itself — covered in Layer 3 acceptance rows 1–4 (preview-verifiable) plus the post-merge workflow run for row 3 + run-side rows 1–2.

Analysis: the diff has no surface area touching the live service runtime. Re-running e2e suites would be a fixed cost with no information return.

## Analysis

Evidence is sufficient for what is verifiable pre-merge: every static acceptance row (1, 2, 4, 5) is satisfied by the committed diff, and every CI gate runs clean on the pushed commit. Row 3 (`systemctl is-active` in 30s) and the gh-run-log content checks for rows 1 and 2 are observable only after a workflow_dispatch or merge-to-main trigger fires; the smoke-check shell logic is unchanged from the v1 path that was previously green, so the residual risk is isolated to pnpm-on-target behavior (which homelab-tf#238 already validated with `pnpm --version → 10.33.0` on VM 106). Recommend a `workflow_dispatch` of `deploy.yml` from this branch immediately after PR open to close the loop on rows 3 / run-log 1 / run-log 2 before merge.
