### PR TITLE
fix(deploy): TARGET use VM 106 real FQDN to bypass orphan netbird DNS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,17 @@ on:
 
 # Pattern A (per Mouriya-Emma/local-cicd-demo §Deployment patterns):
 # build on a github-hosted runner, deploy on the netbird-mesh runner.
-# The deploy step rsyncs dist/ + container/ to deploy@nanoclaw.mouriya.lan
-# then `sudo systemctl restart nanoclaw` and a smoke check.
+# The deploy step rsyncs dist/ + container/ to
+# deploy@nanoclaw-108-124.mouriya.lan then `sudo systemctl restart nanoclaw`
+# and a smoke check.
+#
+# TARGET host note: VM 106's intended short alias `nanoclaw.mouriya.lan`
+# in netbird mesh DNS still points at orphan peer `100.85.157.186` (old
+# CT 105, destroyed). Until the orphan is removed in netbird management
+# and the alias rebound, this workflow uses VM 106's auto-assigned FQDN
+# with IP suffix (`nanoclaw-108-124.mouriya.lan` -> 100.85.108.124).
+# Cleanup tracked in homelab-tf; once the alias resolves to the live IP,
+# revert to the bare `nanoclaw.mouriya.lan` form.
 #
 # Secrets needed (configured in this repo's settings):
 #   DEPLOY_SSH_KEY   - private ed25519 key whose public counterpart is
@@ -111,7 +120,7 @@ jobs:
       - name: Stage SSH key
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          TARGET: nanoclaw.mouriya.lan
+          TARGET: nanoclaw-108-124.mouriya.lan
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
@@ -123,7 +132,7 @@ jobs:
 
       - name: Rsync dist + container + scripts + manifest to /opt/nanoclaw
         env:
-          TARGET: nanoclaw.mouriya.lan
+          TARGET: nanoclaw-108-124.mouriya.lan
         run: |
           rsync -az --delete \
             -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
@@ -141,7 +150,7 @@ jobs:
 
       - name: Install runtime deps on target
         env:
-          TARGET: nanoclaw.mouriya.lan
+          TARGET: nanoclaw-108-124.mouriya.lan
         run: |
           # `--ignore-scripts` skips the `prepare: husky` hook (dev tool
           # not installed in --prod), but it ALSO skips better-sqlite3's
@@ -154,7 +163,7 @@ jobs:
 
       - name: Build agent container image on target (uses Docker layer cache)
         env:
-          TARGET: nanoclaw.mouriya.lan
+          TARGET: nanoclaw-108-124.mouriya.lan
         run: |
           # Build on the target — Dockerfile + agent-runner sources need
           # to land before nanoclaw orchestrator's container-runner.ts
@@ -165,7 +174,7 @@ jobs:
 
       - name: Restart + smoke
         env:
-          TARGET: nanoclaw.mouriya.lan
+          TARGET: nanoclaw-108-124.mouriya.lan
         run: |
           # Boot can take longer than 3 s on first run because better-sqlite3
           # opens the on-disk db and the mattermost/telegram channels run


### PR DESCRIPTION
Closes #83.

## Summary

`deploy.yml` 5 处 `TARGET: nanoclaw.mouriya.lan` 全改为 `TARGET: nanoclaw-108-124.mouriya.lan`（VM 106 真实 mesh FQDN，IP `100.85.108.124`）。顶部加注释记录 alias bug 来源 + 后续 cleanup 路径。其余 deploy 逻辑（rsync、`pnpm install --frozen-lockfile --prod --ignore-scripts && pnpm rebuild better-sqlite3`、systemctl smoke 30s 块）一字未动。

## Layer 1 — Change preview

```
$ git diff --stat HEAD~1
 .github/workflows/deploy.yml | 23 ++++++++++++++++-------
 1 file changed, 16 insertions(+), 7 deletions(-)
```

5 处 TARGET 替换 + 注释扩展（解释 orphan + 临时性）：

```
$ grep -n "TARGET: nanoclaw" .github/workflows/deploy.yml
123:          TARGET: nanoclaw-108-124.mouriya.lan
135:          TARGET: nanoclaw-108-124.mouriya.lan
153:          TARGET: nanoclaw-108-124.mouriya.lan
166:          TARGET: nanoclaw-108-124.mouriya.lan
177:          TARGET: nanoclaw-108-124.mouriya.lan
```

## Layer 2 — Landing checks

| Check | Command | Result |
|---|---|---|
| 5 处 TARGET 全用新 FQDN | `grep -c "TARGET: nanoclaw-108-124.mouriya.lan" .github/workflows/deploy.yml` | `5` |
| 不残留裸 alias 作 TARGET | `grep -E "^ +TARGET: nanoclaw\\.mouriya\\.lan$" .github/workflows/deploy.yml \|\| echo NONE` | `NONE` |
| Pre-commit hook (prettier) | `npm run format:check`（commit 时自动跑，全 `unchanged`） | exit 0 |

## Layer 3 — Apply ordering / runtime evidence

部署逻辑零变动；唯一改的是 SSH target 主机名解析路径。下面证据链证明 vctcn-runner ↔ VM 106 的 mesh 通路在新 FQDN 下成立：

**1. 新 FQDN 在 mesh DNS 解析正确（VM 106 内部视角）：**

```
$ ssh root@pve.hb.lan 'qm guest exec 106 -- bash -c "getent hosts nanoclaw-108-124.mouriya.lan"'
100.85.108.124  nanoclaw-108-124.mouriya.lan
```

**2. VM 106 自身 netbird 状态健康：**

```
$ ssh root@pve.hb.lan 'qm guest exec 106 -- netbird status'
Daemon version: 0.70.5
Management: Connected
Signal: Connected
Relays: 4/4 Available
Nameservers: 1/1 Available
FQDN: nanoclaw-108-124.mouriya.lan
NetBird IP: 100.85.108.124/16
```

**3. VM 106 sshd 在听 + deploy 用户的 authorized_keys 是 vctcn-runner 持有的那把 ed25519：**

```
$ ssh root@pve.hb.lan 'qm guest exec 106 -- bash -c "ss -tlnp | grep :22; cat /home/deploy/.ssh/authorized_keys"'
LISTEN 0 128 0.0.0.0:22 ... users:(("sshd",pid=833,fd=6))
LISTEN 0 128 [::]:22 ... users:(("sshd",pid=833,fd=7))
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINPxMzBMtHZ73k3chU5FGqjB1bLb7UmYbNy49mi0jvyX
```

key comment 与 homelab-tf `_shared/ansible/secrets.yml` 里 `nanoclaw_deploy_ssh_pubkey` 对应（同一 `vctcn-runner-to-nanoclaw-deploy` ed25519，与 `DEPLOY_SSH_KEY` repo secret 私钥成对）。

**4. vctcn-runner 在 mesh 上 alive（PVE 探）：**

```
$ ssh root@pve.hb.lan 'ping -c 2 -W 2 100.85.156.166'
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max/stddev = 178.796/178.981/179.167/0.186 ms
```

**5. 反向 mesh ssh handshake 通（VM 106 → vctcn-runner，证明 mesh 双向通达；Permission denied 是预期 — VM 106 deploy 没 vctcn-runner 的 key）：**

```
$ ssh root@pve.hb.lan 'qm guest exec 106 -- bash -c "ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=3 deploy@vctcn-runner.mouriya.lan true"'
Warning: Permanently added 'vctcn-runner.mouriya.lan' (ED25519) ...
deploy@vctcn-runner.mouriya.lan: Permission denied (publickey).
```

## Layer 4 — End-to-end

merge 后 `push` 触发 deploy run；本 PR 的 verdict 锁在 run conclusion = SUCCESS + VM 106 `systemctl is-active nanoclaw = active`。会在 PR comment 跟评 deploy run url + qm guest exec 取的 systemctl 输出（不依赖 coder-loop self-review，由 author 手动 watch + 取证）。

## Analysis

根因（PR 触发的 deploy run [#25768760113](https://github.com/Mouriya-Emma/nanoclaw/actions/runs/25768760113) 失败之后调查得出）：

> netbird mesh DNS 中 `nanoclaw.mouriya.lan` 仍指向 orphan peer `100.85.157.186`（旧 CT 105 destroyed 后管理后台未清，status `Connecting`）。VM 106 enroll 时 hostname `nanoclaw` 已被占用，netbird 自动加 IP suffix → 真实 FQDN 为 `nanoclaw-108-124.mouriya.lan`。vctcn-runner 走 mesh DNS 撞死 IP → `ssh-keyscan` 在 `bash -e` + `2>/dev/null` 下静默 exit 1 → 整个 deploy job 早死。

mesh 中实际还有 2 个 nanoclaw orphan peer（`100.85.157.186`、`100.85.158.65`），从 PVE host `qm guest exec 106 -- netbird status --detail` 可观测。

本 PR 是 **临时 unblock**：不动 netbird 后台、不动 ansible role、不动 PVE `/etc/hosts`，仅在 deploy.yml 改 5 处 TARGET。后续永久 fix（删 orphan peer + bind alias `nanoclaw` → 100.85.108.124）走 homelab-tf 跟进 issue；alias 修好后再 revert 本 PR。

唯一残留风险：VM 106 重建会得到新的 mesh IP（IP suffix 也变），需要再次手改 deploy.yml。这正是为什么永久 fix 必须走 alias 路线。

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>