### PR TITLE
fix(deploy): rsync setup/ to target so build.sh can source install-slug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,15 @@ jobs:
           name: scripts
           path: scripts/
           retention-days: 1
+      # Ship setup/ too — container/build.sh sources setup/lib/install-slug.sh
+      # to derive the per-install image name (`container_image_base`), so the
+      # deploy step's `bash ./build.sh` invocation needs setup/lib/ present
+      # under /opt/nanoclaw on the target.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: setup
+          path: setup/
+          retention-days: 1
       # Ship the manifest pair so the deploy step can install runtime deps on
       # the target via `pnpm install --frozen-lockfile --prod`. Compiling
       # native modules against the build runner's glibc and shipping
@@ -102,6 +111,11 @@ jobs:
         with:
           name: scripts
           path: scripts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: setup
+          path: setup/
 
       - uses: actions/download-artifact@v4
         with:
@@ -143,6 +157,9 @@ jobs:
           rsync -az --delete \
             -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
             scripts/ "deploy@${TARGET}:/opt/nanoclaw/scripts/"
+          rsync -az --delete \
+            -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
+            setup/ "deploy@${TARGET}:/opt/nanoclaw/setup/"
           rsync -az \
             -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
             package.json pnpm-lock.yaml \


### PR DESCRIPTION
Closes #85.

## Summary

`deploy.yml` build job 增上传 `setup/` artifact，deploy job 增 download + rsync 到 `/opt/nanoclaw/setup/`，匹配 `container/build.sh:19` 对 `$PROJECT_ROOT/setup/lib/install-slug.sh` 的 `source` 依赖（v2.0.54 引入，PR #82 deploy.yml 重写时漏跟）。其余 deploy 逻辑零变动。

## Layer 1 — Change preview

```
$ git diff --stat HEAD~1
 .github/workflows/deploy.yml | 17 +++++++++++++++++
 1 file changed, 17 insertions(+)
```

三处 hunk：

1. build job 加一条 `actions/upload-artifact@v4` (`name: setup`, `path: setup/`)
2. deploy job 加一条 `actions/download-artifact@v4` (`name: setup`, `path: setup/`)
3. Rsync step 增一条 `rsync -az --delete ... setup/ "deploy@${TARGET}:/opt/nanoclaw/setup/"`

artifact 命名与已有 4 个 (dist/container/scripts/manifest) 风格一致；`--delete` 维持 rsync 镜像语义。

## Layer 2 — Landing checks

| Check | Command | Result |
|---|---|---|
| build job 上传 setup artifact | `grep -c "name: setup" .github/workflows/deploy.yml` | `2`（1 upload + 1 download）|
| deploy job rsync setup/ | `grep -c "setup/" .github/workflows/deploy.yml` | `5`（注释 1 + upload path 1 + download path 1 + rsync src 1 + rsync dst 1）|
| 本地 setup/lib/install-slug.sh 存在 | `test -f setup/lib/install-slug.sh && echo OK` | `OK` |
| Pre-commit hook (prettier) | commit 时自动跑 | exit 0（all `unchanged`） |

## Layer 3 — Apply ordering / runtime evidence

前置 unblock（PR #84，DNS fix）证据：上一次 deploy run [#25770016798](https://github.com/Mouriya-Emma/nanoclaw/actions/runs/25770016798) 已成功通过 `Stage SSH key` → `Rsync` → `Install runtime deps on target`，仅在本 PR fix 的 `Build agent container image on target` 步死：

> `./build.sh: line 19: /opt/nanoclaw/setup/lib/install-slug.sh: No such file or directory`
> `##[error]Process completed with exit code 1.`

本地 fork 仓内 `setup/lib/install-slug.sh` 存在且 build.sh 源它定义 `container_image_base` shell 函数 ([commit log on this file](https://github.com/Mouriya-Emma/nanoclaw/blame/main/container/build.sh) 表明 line 19 source 是 v2 baseline 既有行为）。本 PR 把 setup/ 加入 artifact + rsync 后，`/opt/nanoclaw/setup/lib/install-slug.sh` 在 VM 106 上 will exist with same content；source 不再 fail。

## Layer 4 — End-to-end

merge 后 push 触发 deploy run；由 author 手动 watch + 取 `qm guest exec 106 -- systemctl is-active nanoclaw` 输出。PR comment 跟评 run url + active 输出。

## Analysis

PR #82 deploy.yml v2 重写专注 npm→pnpm 切换 + manifest 文件名，没回看 v2 build.sh 是否引入新的 host-side 依赖。本 PR 是 #82 的 follow-up，与 #83 (DNS) 一起把"PR #82 把代码 merge 了但 deploy 实际跑不通"的两个根因清掉。这也再次印证 #80 umbrella 真正的 acceptance 应该是 "VM 106 systemctl is-active = active 且服务能响应消息"——不是"deploy.yml 文件 syntactically correct"。

residual risk：`setup/` 全目录 rsync 会把 ts/sh 都送上去，VM 106 上不会主动跑这些（systemd unit 只 exec `nanoclaw-launch.sh` → `node dist/index.js`），但盘上多 ~几百 KB 的 setup 脚本。`build.sh` 实际只需 `setup/lib/install-slug.sh` 一个文件，若后续要收窄可以单文件 artifact；本 PR 选整目录以保持和 v1 行为 + manifest/scripts pattern 一致。

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>