### PR TITLE
fix(deploy): ship pnpm-workspace.yaml to target (closes #87)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,17 +79,23 @@ jobs:
           name: setup
           path: setup/
           retention-days: 1
-      # Ship the manifest pair so the deploy step can install runtime deps on
+      # Ship the manifest trio so the deploy step can install runtime deps on
       # the target via `pnpm install --frozen-lockfile --prod`. Compiling
       # native modules against the build runner's glibc and shipping
       # node_modules works for prebuilt packages but breaks for anything
       # that needs to compile, so we trade slower deploy for reliability.
+      # `pnpm-workspace.yaml` carries the `onlyBuiltDependencies` allowlist
+      # — pnpm v10 default-denies dependency build scripts, so without this
+      # file `pnpm rebuild better-sqlite3` is silently a no-op and the
+      # service crashes on boot with "Could not locate the bindings file"
+      # (issue #87).
       - uses: actions/upload-artifact@v4
         with:
           name: manifest
           path: |
             package.json
             pnpm-lock.yaml
+            pnpm-workspace.yaml
           retention-days: 1
 
   deploy:
@@ -162,7 +168,7 @@ jobs:
             setup/ "deploy@${TARGET}:/opt/nanoclaw/setup/"
           rsync -az \
             -e 'ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes' \
-            package.json pnpm-lock.yaml \
+            package.json pnpm-lock.yaml pnpm-workspace.yaml \
             "deploy@${TARGET}:/opt/nanoclaw/"
 
       - name: Install runtime deps on target


### PR DESCRIPTION
Closes #87

## 改动

`.github/workflows/deploy.yml`：把 `pnpm-workspace.yaml` 加入 `manifest` artifact + rsync 到 `/opt/nanoclaw/`。注释说明 pnpm v10 default-deny + circuit breaker 掩盖 fail 的双重 trap。

## 为什么

pnpm v10 默认禁止依赖 build script。`pnpm-workspace.yaml` 里的 `onlyBuiltDependencies: [better-sqlite3, esbuild, protobufjs, sharp]` 是 allowlist。target 上没有这个文件 → `pnpm rebuild better-sqlite3` 没出错也没产 .node binding → orchestrator 启动 FATAL 在 `Could not locate the bindings file`。

详细诊断 + 证据原文在 #87 body。

## 验证（手动 repair 已确认）

scp `pnpm-workspace.yaml` 到 VM 106 + rerun rebuild 后：

**before**

```
$ pnpm rebuild better-sqlite3 > /tmp/rebuild.log 2>&1; wc -l /tmp/rebuild.log
0 /tmp/rebuild.log
$ ls .../better-sqlite3/build/Release/
ls: cannot access '...': No such file or directory
```

**after**

```
$ pnpm rebuild better-sqlite3
.../node_modules/better-sqlite3 install$ prebuild-install || node-gyp rebuild --release
.../node_modules/better-sqlite3 install: Done
$ ls -la .../better-sqlite3/build/Release/better_sqlite3.node
-rwxrwxr-x 1 deploy deploy 2072760 ... better_sqlite3.node
```

restart service：

```
$ systemctl restart nanoclaw && sleep 8 && systemctl is-active nanoclaw
active

$ journalctl -u nanoclaw -n 5 --no-pager | tail -1
[00:48:51.853] INFO NanoClaw running

$ systemctl show nanoclaw -p NRestarts -p MainPID -p MemoryCurrent
NRestarts=0
MainPID=2237
MemoryCurrent=81944576
```

real boot — 13 migrations applied、Central DB ready、CLI socket up、`NanoClaw running`，不再 FATAL。

CI-side 验证在 PR merge 后的 deploy run 里：Acceptance #1-#7 in #87。

## Acceptance #1 / #2（PR 内可验）

```
$ grep -n pnpm-workspace.yaml .github/workflows/deploy.yml
86:            pnpm-workspace.yaml
160:            package.json pnpm-lock.yaml pnpm-workspace.yaml \
```

via [HAPI](https://hapi.run)