### PR TITLE
fix(onecli): prefix agent identifier with `ag-` for self-hosted OneCLI 1.23.0

### DIFF
--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -26,6 +26,7 @@ import { CONTAINER_RUNTIME_BIN, hostGatewayArgs, readonlyMountArgs, stopContaine
 import { composeGroupClaudeMd } from './claude-md-compose.js';
 import { getAgentGroup } from './db/agent-groups.js';
 import { getDb, hasTable } from './db/connection.js';
+import { toOneCLIIdentifier } from './fork-features/onecli-identifier.js';
 import { initGroupFilesystem } from './group-init.js';
 import { stopTypingRefresh } from './modules/typing/index.js';
 import { log } from './log.js';
@@ -133,9 +134,11 @@ async function spawnContainer(session: Session): Promise<void> {
 
   const mounts = buildMounts(agentGroup, session, containerConfig, contribution);
   const containerName = `nanoclaw-v2-${agentGroup.folder}-${Date.now()}`;
-  // OneCLI agent identifier is always the agent group id — stable across
-  // sessions and reversible via getAgentGroup() for approval routing.
-  const agentIdentifier = agentGroup.id;
+  // OneCLI agent identifier is derived from the agent group id and reversed
+  // by `fromOneCLIIdentifier` for approval routing. Self-hosted OneCLI
+  // 1.23.0 enforces letter-first / lowercase / hyphen-only — UUIDs that
+  // start with a digit get rejected without the prefix.
+  const agentIdentifier = toOneCLIIdentifier(agentGroup.id);
   const args = await buildContainerArgs(
     mounts,
     containerName,

--- a/src/fork-features/onecli-identifier.test.ts
+++ b/src/fork-features/onecli-identifier.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { fromOneCLIIdentifier, toOneCLIIdentifier } from './onecli-identifier.js';
+
+describe('toOneCLIIdentifier', () => {
+  it('prefixes a UUID that starts with a digit so OneCLI letter-first rule passes', () => {
+    expect(toOneCLIIdentifier('5dec44de-074a-4131-9472-da38f8097438')).toBe('ag-5dec44de-074a-4131-9472-da38f8097438');
+  });
+
+  it('prefixes a UUID that starts with a letter (uniformity, not branching by content)', () => {
+    expect(toOneCLIIdentifier('abc44de2-074a-4131-9472-da38f8097438')).toBe('ag-abc44de2-074a-4131-9472-da38f8097438');
+  });
+
+  it('produces a string within OneCLI 1-50 char limit for a standard UUID input', () => {
+    const out = toOneCLIIdentifier('5dec44de-074a-4131-9472-da38f8097438');
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    expect(out.length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe('fromOneCLIIdentifier', () => {
+  it('strips the ag- prefix to recover the agent group id', () => {
+    expect(fromOneCLIIdentifier('ag-5dec44de-074a-4131-9472-da38f8097438')).toBe(
+      '5dec44de-074a-4131-9472-da38f8097438',
+    );
+  });
+
+  it('passes a non-prefixed identifier through unchanged for backward compatibility', () => {
+    expect(fromOneCLIIdentifier('5dec44de-074a-4131-9472-da38f8097438')).toBe('5dec44de-074a-4131-9472-da38f8097438');
+  });
+
+  it('returns undefined when input is undefined', () => {
+    expect(fromOneCLIIdentifier(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when input is null (matches @onecli-sh/sdk externalId nullable shape)', () => {
+    expect(fromOneCLIIdentifier(null)).toBeUndefined();
+  });
+
+  it('is idempotent under re-stripping', () => {
+    const id = 'ag-5dec44de-074a-4131-9472-da38f8097438';
+    expect(fromOneCLIIdentifier(fromOneCLIIdentifier(id))).toBe('5dec44de-074a-4131-9472-da38f8097438');
+  });
+});
+
+describe('round trip', () => {
+  it('to-then-from recovers the original group id', () => {
+    const id = '5dec44de-074a-4131-9472-da38f8097438';
+    expect(fromOneCLIIdentifier(toOneCLIIdentifier(id))).toBe(id);
+  });
+});

--- a/src/fork-features/onecli-identifier.ts
+++ b/src/fork-features/onecli-identifier.ts
@@ -1,0 +1,30 @@
+/**
+ * OneCLI agent identifier transform.
+ *
+ * Self-hosted OneCLI 1.23.0 enforces a stricter identifier format than the
+ * SaaS endpoint nanoclaw was originally written against:
+ *
+ *   1-50 chars, MUST start with a letter, lowercase letters / numbers /
+ *   hyphens only.
+ *
+ * `agentGroup.id` is a UUID (e.g. `5dec44de-074a-4131-9472-da38f8097438`)
+ * which often starts with a digit and gets rejected with HTTP 400. We prefix
+ * `ag-` so the value clears the letter-first rule while staying within 50
+ * chars (`ag-` + 36-char UUID = 39 chars).
+ *
+ * `fromOneCLIIdentifier` strips the prefix when the OneCLI approval handler
+ * (`src/modules/approvals/onecli-approvals.ts`) needs to reverse-look-up the
+ * agent group by id. Identifiers without the prefix pass through untouched
+ * so any pre-existing OneCLI-side records still resolve.
+ */
+
+const ONECLI_ID_PREFIX = 'ag-';
+
+export function toOneCLIIdentifier(groupId: string): string {
+  return `${ONECLI_ID_PREFIX}${groupId}`;
+}
+
+export function fromOneCLIIdentifier(identifier: string | null | undefined): string | undefined {
+  if (!identifier) return undefined;
+  return identifier.startsWith(ONECLI_ID_PREFIX) ? identifier.slice(ONECLI_ID_PREFIX.length) : identifier;
+}

--- a/src/fork-features/trunk-patches.md
+++ b/src/fork-features/trunk-patches.md
@@ -1,0 +1,27 @@
+# Tracked trunk patches
+
+Each entry below is a small edit to an upstream file that fork-features cannot fully encapsulate, because upstream lacks a register-style extension point at the call site. At every rebase, walk this list — if upstream has since added a register API or made the concern obsolete, migrate the patch into `fork-features/` or drop it.
+
+Format per entry: file/line, what the patch does, why extraction isn't possible today.
+
+## OneCLI identifier transform (issue Mouriya-Emma/nanoclaw#90)
+
+### `src/container-runner.ts` — call to `toOneCLIIdentifier`
+
+- Patch:
+  - Add `import { toOneCLIIdentifier } from './fork-features/onecli-identifier.js';`
+  - Change `const agentIdentifier = agentGroup.id;` to `const agentIdentifier = toOneCLIIdentifier(agentGroup.id);`
+- Why a patch and not pure fork-features: `agentIdentifier` is a local in `spawnContainer` consumed by `buildContainerArgs(... agentIdentifier)`. Upstream has no hook for "compute the OneCLI identifier from an agent group" — the only call site is this one literal assignment. Extracting would require adding a `getOneCLIIdentifier(group)` extension point upstream.
+
+### `src/modules/approvals/onecli-approvals.ts` — call to `fromOneCLIIdentifier`
+
+- Patch:
+  - Add `import { fromOneCLIIdentifier } from '../../fork-features/onecli-identifier.js';`
+  - Change `const originGroup = request.agent.externalId ? getAgentGroup(request.agent.externalId) : undefined;` to use `fromOneCLIIdentifier` then `getAgentGroup`.
+- Why a patch and not pure fork-features: the reverse-lookup happens inside the manual-approval handler upstream owns. Upstream takes `request.agent.externalId` straight to `getAgentGroup`. Symmetry with the forward-transform patch above; same missing extension point.
+
+## Rebase checklist for these two
+
+When rebasing onto a new upstream version:
+1. Has upstream added a `registerOneCLIIdentifierTransform` (or equivalent) extension point? Migrate both patches into a single `fork-features/onecli-identifier.ts` self-registration call and drop these entries.
+2. Has upstream changed how `agentGroup.id` is consumed by `ensureAgent` (e.g. moved the transform server-side, switched away from `@onecli-sh/sdk`)? The patches may be obsolete — verify with a smoke test against a self-hosted OneCLI before keeping them.

--- a/src/modules/approvals/onecli-approvals.ts
+++ b/src/modules/approvals/onecli-approvals.ts
@@ -22,6 +22,7 @@ import { OneCLI, type ApprovalRequest, type ManualApprovalHandle } from '@onecli
 import { pickApprovalDelivery, pickApprover } from './primitive.js';
 import { ONECLI_API_KEY, ONECLI_URL } from '../../config.js';
 import { getAgentGroup } from '../../db/agent-groups.js';
+import { fromOneCLIIdentifier } from '../../fork-features/onecli-identifier.js';
 import {
   createPendingApproval,
   deletePendingApproval,
@@ -114,9 +115,11 @@ async function handleRequest(request: ApprovalRequest): Promise<Decision> {
   if (!adapterRef) return 'deny';
 
   // Originating agent group is carried on the request via OneCLI's agent
-  // identifier (set by container-runner.ts to agentGroup.id). Use it as
-  // the scope for approver selection: admin @ group → global admin → owner.
-  const originGroup = request.agent.externalId ? getAgentGroup(request.agent.externalId) : undefined;
+  // identifier (set by container-runner.ts via toOneCLIIdentifier). Strip
+  // the fork prefix before the lookup; non-prefixed values pass through
+  // unchanged so legacy OneCLI-side records still resolve.
+  const groupId = fromOneCLIIdentifier(request.agent.externalId);
+  const originGroup = groupId ? getAgentGroup(groupId) : undefined;
   const agentGroupId = originGroup?.id ?? null;
   const approvers = pickApprover(agentGroupId);
   if (approvers.length === 0) {


### PR DESCRIPTION
## Summary

- Self-hosted OneCLI 1.23.0 (deployed under `Mouriya-Emma/homelab-tf#243`) enforces letter-first / lowercase / hyphen-only identifier validation. UUIDs starting with a digit (e.g. `5dec44de-...`) get HTTP 400. SaaS endpoint was lenient enough to accept them; self-host surfaced the gap.
- New `src/fork-features/onecli-identifier.ts` exports `toOneCLIIdentifier` (`ag-` prefix) and `fromOneCLIIdentifier` (strip prefix, idempotent on legacy non-prefixed values).
- Two minimal trunk patches (`container-runner.ts` + `onecli-approvals.ts`) — each gain 1 import + 1 call-site swap. Tracked in `src/fork-features/trunk-patches.md` for rebase audit.

Closes #90

## Evidence

### Local typecheck + tests + build

```
$ pnpm typecheck
> tsc --noEmit
(exit 0)

$ pnpm exec vitest run src/fork-features/onecli-identifier.test.ts src/modules/approvals/
Test Files  2 passed (2)
Tests  15 passed (15)

$ pnpm build
> tsc
(exit 0, dist/fork-features/onecli-identifier.js emitted)
```

### Direct OneCLI server validation (VM 106 → moat-app1.hb.lan:10254)

Before fix — UUID with digit-first identifier:

```
$ curl -X POST -H 'Authorization: Bearer $ONECLI_API_KEY' \
    -H 'Content-Type: application/json' \
    -d '{"name":"test","identifier":"5dec44de-074a-4131-9472-da38f8097438"}' \
    http://moat-app1.hb.lan:10254/api/agents
{"error":"Identifier must be 1-50 characters, start with a letter,
         and contain only lowercase letters, numbers, and hyphens"}
```

After fix — same UUID with `ag-` prefix (this PR's transform):

```
$ curl -X POST -H 'Authorization: Bearer $ONECLI_API_KEY' \
    -H 'Content-Type: application/json' \
    -d '{"name":"smoke-prefix-test","identifier":"ag-5dec44de-074a-4131-9472-da38f8097438"}' \
    http://moat-app1.hb.lan:10254/api/agents
HTTP 201
{"id":"785cb4aa-4591-45a0-a936-232d154f795c",
 "name":"smoke-prefix-test",
 "identifier":"ag-5dec44de-074a-4131-9472-da38f8097438",
 "createdAt":"2026-05-13T05:38:46.644Z"}
```

Test agent then deleted (HTTP 204) so the deployed code re-creates cleanly with the real `name=smoke`.

### Post-deploy verification (planned, runs after this PR auto-deploys)

- VM 106 journal: `wakeContainer` no longer logs `[StatusCode=400]`
- `docker ps --filter label=nanoclaw-install` shows an active `nanoclaw-v2-smoke-<ts>` container
- OneCLI dashboard at `http://moat-app1.mouriya.lan:10254` lists agent `ag-5dec44de-...` with name `smoke`

If the next layer (Anthropic provider not registered in OneCLI vault, per #243 comment) blocks spawn, that's tracked separately and out of scope for this PR.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec vitest run src/fork-features/onecli-identifier.test.ts src/modules/approvals/` all green (15/15)
- [x] `pnpm build` emits `dist/fork-features/onecli-identifier.js`
- [x] Direct curl 201 against self-hosted OneCLI confirms the transformed identifier is accepted (evidence above)
- [ ] After auto-deploy: VM 106 journal shows spawn passing OneCLI agent registration step (not blocked on this PR — verified post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)