### PR TITLE
feat(spike): verify Claude Code channel headless turn loop (closes #93)

### DIFF
--- a/scripts/spikes/claude-channel-headless-smoke.sh
+++ b/scripts/spikes/claude-channel-headless-smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Spike for issue #93: prove that Claude Code CLI in NanoClaw target
+# headless form can receive a deliver.message via the agent-channel
+# exchange MCP server, and can reply via channel.send.
+#
+# This shell entry just resolves paths and execs the bun runner. The
+# bun runner owns the full lifecycle: start exchange, register harness,
+# spawn `claude -p` with --mcp-config pointing at @agent-channel/mcp,
+# observe both directions, exit non-zero on any failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+: "${EXCHANGE_ROOT:=/Users/mouriya/Ext/code/agent-channel-exchange}"
+: "${EVIDENCE_DIR:=$REPO_ROOT/.coder-loop/runtime/evidence/issue-93}"
+: "${EXCHANGE_PORT:=18787}"
+: "${SPIKE_MODEL:=sonnet}"
+
+mkdir -p "$EVIDENCE_DIR"
+
+export EXCHANGE_ROOT EVIDENCE_DIR EXCHANGE_PORT SPIKE_MODEL REPO_ROOT
+
+exec bun run "$SCRIPT_DIR/claude-channel-headless-smoke.ts" "$@"

--- a/scripts/spikes/claude-channel-headless-smoke.ts
+++ b/scripts/spikes/claude-channel-headless-smoke.ts
@@ -1,0 +1,514 @@
+// Spike runner for issue #93. Drives an end-to-end loop:
+//   exchange HTTP server  →  spike-harness mailbox (raw HTTP)
+//                          ↘
+//                            nanoclaw/spike-target mailbox  ←  claude -p --mcp-config (@agent-channel/mcp)
+//
+// Verifies BOTH directions of the Claude Code channel turn-loop
+// assumption from RFC #92:
+//   1. RECEIVE: agent inside `claude -p` (headless) calls
+//      mcp__agent-channel__channel.poll_inbox and sees a spike.ping
+//      envelope that the harness pushed.
+//   2. SEND:   agent calls mcp__agent-channel__channel.send with a
+//      spike.pong reply; the harness drains its inbox and sees the
+//      pong with the same nonce.
+//
+// Required env (resolved by the bash wrapper):
+//   EXCHANGE_ROOT      absolute path to agent-channel-exchange clone
+//   EVIDENCE_DIR       where to drop logs / transcripts
+//   EXCHANGE_PORT      TCP port to bind exchange on (default 18787)
+//   SPIKE_MODEL        claude --model (default sonnet)
+//   REPO_ROOT          nanoclaw repo root
+//
+// Exit code:
+//   0  → both directions verified, prints `SPIKE_RESULT_OK ...`
+//   1  → at least one direction failed, prints `SPIKE_RESULT_FAIL ...`
+//   2  → environment / preconditions broken
+
+import { spawn } from "bun";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const procEnv = process.env;
+const EXCHANGE_ROOT = required(procEnv.EXCHANGE_ROOT, "EXCHANGE_ROOT");
+const EVIDENCE_DIR = required(procEnv.EVIDENCE_DIR, "EVIDENCE_DIR");
+const EXCHANGE_PORT = Number(procEnv.EXCHANGE_PORT ?? "18787");
+const SPIKE_MODEL = procEnv.SPIKE_MODEL ?? "sonnet";
+
+mkdirSync(EVIDENCE_DIR, { recursive: true });
+
+const EXCHANGE_URL = `http://127.0.0.1:${EXCHANGE_PORT}`;
+const HARNESS_ID = "spike-harness";
+const TARGET_ID = "nanoclaw/spike-target";
+const SCHEMA_VERSION = "0.1.0";
+
+const NONCE = `n-${Math.random().toString(36).slice(2, 10)}`;
+const RUN_TS = new Date().toISOString().replace(/[:.]/g, "-");
+
+const exchangeLogPath = join(EVIDENCE_DIR, `exchange-${RUN_TS}.log`);
+const claudeStdoutPath = join(EVIDENCE_DIR, `claude-stdout-${RUN_TS}.json`);
+const claudeStderrPath = join(EVIDENCE_DIR, `claude-stderr-${RUN_TS}.log`);
+const transcriptPath = join(EVIDENCE_DIR, `transcript-${RUN_TS}.md`);
+const mcpConfigPath = join(EVIDENCE_DIR, `mcp-config-${RUN_TS}.json`);
+
+type AnySubproc = ReturnType<typeof spawn>;
+let exchangeProc: AnySubproc | null = null;
+let claudeProc: AnySubproc | null = null;
+
+function cleanup(): void {
+  try {
+    claudeProc?.kill();
+  } catch {}
+  try {
+    exchangeProc?.kill();
+  } catch {}
+}
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});
+
+function required(value: string | undefined, name: string): string {
+  if (!value || value.length === 0) {
+    console.error(`[spike] env var ${name} is required`);
+    process.exit(2);
+  }
+  return value;
+}
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+function ulid(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function waitFor<T>(
+  what: string,
+  fn: () => Promise<T | null>,
+  opts: { timeoutMs: number; intervalMs?: number } = { timeoutMs: 30_000 },
+): Promise<T> {
+  const start = Date.now();
+  const interval = opts.intervalMs ?? 200;
+  while (Date.now() - start < opts.timeoutMs) {
+    const v = await fn();
+    if (v !== null) return v;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`timed out waiting for ${what} after ${opts.timeoutMs}ms`);
+}
+
+async function postJson(
+  path: string,
+  body: unknown,
+  senderId?: string,
+): Promise<{ status: number; body: unknown }> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (senderId) headers["x-agent-channel-sender"] = senderId;
+  const resp = await fetch(`${EXCHANGE_URL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await resp.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = text;
+  }
+  return { status: resp.status, body: parsed };
+}
+
+async function pipeIntoFile(
+  stream: ReadableStream<Uint8Array> | null,
+  destPath: string,
+  bufferRef?: { value: string },
+): Promise<void> {
+  if (!stream) return;
+  const decoder = new TextDecoder();
+  // Truncate file first
+  writeFileSync(destPath, "");
+  for await (const chunk of stream) {
+    const text = decoder.decode(chunk);
+    if (bufferRef) bufferRef.value += text;
+    appendFileSync(destPath, text);
+  }
+}
+
+async function startExchange(): Promise<void> {
+  console.log(`[spike] starting exchange on ${EXCHANGE_URL}`);
+  exchangeProc = spawn({
+    cmd: ["bun", "run", `${EXCHANGE_ROOT}/packages/exchange/src/index.ts`],
+    env: { ...procEnv, PORT: String(EXCHANGE_PORT), HOSTNAME: "127.0.0.1" },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  // Tee both into the exchange log
+  void pipeIntoFile(exchangeProc.stdout as ReadableStream<Uint8Array>, exchangeLogPath);
+  void pipeIntoFile(exchangeProc.stderr as ReadableStream<Uint8Array>, exchangeLogPath + ".stderr");
+  await waitFor(
+    "exchange /version",
+    async () => {
+      try {
+        const resp = await fetch(`${EXCHANGE_URL}/version`);
+        if (resp.ok) return await resp.json();
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    { timeoutMs: 15_000, intervalMs: 200 },
+  );
+  console.log(`[spike] exchange up`);
+}
+
+async function registerHarness(): Promise<void> {
+  const envelope = {
+    msg_id: ulid(),
+    from: HARNESS_ID,
+    to: "exchange/system",
+    ts: isoNow(),
+    schema_version: SCHEMA_VERSION,
+    body: {
+      kind: "register.request",
+      payload: {
+        schema_version: SCHEMA_VERSION,
+        desired_channel_id: HARNESS_ID,
+        capabilities: ["channel.send", "channel.receive", "discovery.list"],
+        identity: {
+          agent_kind: "pm-agent",
+          instance_label: "spike-harness",
+        },
+      },
+    },
+  };
+  const { status, body } = await postJson("/v1/register", envelope);
+  if (status !== 200) {
+    throw new Error(
+      `harness register failed: status=${status} body=${JSON.stringify(body).slice(0, 400)}`,
+    );
+  }
+  console.log(`[spike] harness registered as ${HARNESS_ID}`);
+}
+
+function buildMcpConfig(): string {
+  const cfg = {
+    mcpServers: {
+      "agent-channel": {
+        command: "bun",
+        args: ["run", `${EXCHANGE_ROOT}/packages/mcp/src/bin.ts`],
+        env: {
+          AGENT_CHANNEL_EXCHANGE_URL: EXCHANGE_URL,
+          AGENT_CHANNEL_DESIRED_ID: TARGET_ID,
+          AGENT_CHANNEL_AGENT_KIND: "worker-agent",
+          AGENT_CHANNEL_INSTANCE_LABEL: "spike-target",
+          AGENT_CHANNEL_CAPABILITIES: "channel.send,channel.receive,discovery.list",
+        },
+      },
+    },
+  };
+  writeFileSync(mcpConfigPath, JSON.stringify(cfg, null, 2));
+  return mcpConfigPath;
+}
+
+async function waitForTargetRegistration(): Promise<void> {
+  await waitFor(
+    `${TARGET_ID} to appear in discovery`,
+    async () => {
+      const envelope = {
+        msg_id: ulid(),
+        from: HARNESS_ID,
+        to: "exchange/system",
+        ts: isoNow(),
+        schema_version: SCHEMA_VERSION,
+        body: { kind: "discovery.list_request", payload: {} },
+      };
+      try {
+        const { body } = await postJson("/v1/discovery/list", envelope, HARNESS_ID);
+        const list = body as {
+          body?: { kind?: string; payload?: { channels?: Array<{ channel_id: string }> } };
+        };
+        const channels = list?.body?.payload?.channels ?? [];
+        if (channels.some((c) => c.channel_id === TARGET_ID)) return true;
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    { timeoutMs: 60_000, intervalMs: 500 },
+  );
+  console.log(`[spike] ${TARGET_ID} is registered`);
+}
+
+async function sendPing(): Promise<string> {
+  const msgId = ulid();
+  const envelope = {
+    msg_id: msgId,
+    from: HARNESS_ID,
+    to: TARGET_ID,
+    ts: isoNow(),
+    schema_version: SCHEMA_VERSION,
+    body: {
+      kind: "deliver.message",
+      payload: {
+        body_kind: "spike.ping",
+        payload: { nonce: NONCE },
+      },
+    },
+  };
+  const { status, body } = await postJson("/v1/envelope", envelope, HARNESS_ID);
+  const wire = body as { response?: { body?: { kind?: string; payload?: unknown } } };
+  if (status !== 200 || wire.response?.body?.kind === "deliver.error") {
+    throw new Error(
+      `ping send failed: status=${status} response=${JSON.stringify(wire.response).slice(0, 400)}`,
+    );
+  }
+  console.log(`[spike] sent spike.ping msg_id=${msgId} nonce=${NONCE}`);
+  return msgId;
+}
+
+async function drainHarnessInbox(): Promise<unknown[]> {
+  const envelope = {
+    msg_id: ulid(),
+    from: HARNESS_ID,
+    to: "exchange/system",
+    ts: isoNow(),
+    schema_version: SCHEMA_VERSION,
+    body: {
+      kind: "heartbeat.ping",
+      payload: { channel_id: HARNESS_ID, sequence: 0 },
+    },
+  };
+  const { body } = await postJson("/v1/envelope", envelope, HARNESS_ID);
+  const wire = body as { inbox?: unknown[] };
+  return wire.inbox ?? [];
+}
+
+type PongEnvelope = {
+  msg_id: string;
+  in_reply_to?: string;
+  body: { kind: string; payload: { body_kind: string; payload: unknown } };
+};
+
+function extractNonce(payload: unknown): string | undefined {
+  // Claude Code's MCP tool dispatch may pass our `payload` argument either as
+  // a structured object (the expected shape) or, in practice, as a stringified
+  // JSON blob — depending on the model's serialization choice for unstructured
+  // arguments. Accept both forms.
+  if (payload && typeof payload === "object" && "nonce" in payload) {
+    const n = (payload as { nonce?: unknown }).nonce;
+    return typeof n === "string" ? n : undefined;
+  }
+  if (typeof payload === "string") {
+    try {
+      const parsed = JSON.parse(payload) as { nonce?: unknown };
+      return typeof parsed.nonce === "string" ? parsed.nonce : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+async function waitForPong(): Promise<PongEnvelope> {
+  return waitFor<PongEnvelope>(
+    "spike.pong on harness inbox",
+    async () => {
+      const inbox = await drainHarnessInbox();
+      for (const item of inbox) {
+        const env = item as PongEnvelope;
+        if (env.body?.kind === "deliver.message") {
+          appendTranscript("- raw inbox envelope:");
+          appendTranscript("```json");
+          appendTranscript(JSON.stringify(item, null, 2));
+          appendTranscript("```");
+        }
+        if (
+          env.body?.kind === "deliver.message" &&
+          env.body.payload?.body_kind === "spike.pong"
+        ) {
+          return env;
+        }
+      }
+      return null;
+    },
+    { timeoutMs: 180_000, intervalMs: 1_000 },
+  );
+}
+
+async function runClaude(): Promise<{ exitCode: number; transcript: string }> {
+  const prompt = [
+    "You are running inside an automated spike test that proves a Claude Code MCP channel can be used as a turn loop.",
+    "",
+    "You have access to two MCP tools from the `agent-channel` server:",
+    "- `mcp__agent-channel__channel.poll_inbox` — drains pending inbox events and returns them.",
+    "- `mcp__agent-channel__channel.send` — sends one envelope to another mailbox.",
+    "",
+    "Procedure (do this exactly, no questions, no commentary):",
+    "1. Call `mcp__agent-channel__channel.poll_inbox` with `{}` as arguments.",
+    "2. Inspect the returned `events` array. Find the event whose `channel_event.body_kind` equals `\"spike.ping\"`.",
+    "   - If no such event is present yet, repeat step 1 up to 8 times with no other actions in between.",
+    "3. From that event capture:",
+    "   - `nonce` = `channel_event.payload.nonce` (a string)",
+    "   - `ping_msg_id` = `envelope_meta.msg_id`",
+    "4. Call `mcp__agent-channel__channel.send` with arguments exactly:",
+    "   `{\"to\":\"spike-harness\",\"body_kind\":\"spike.pong\",\"payload\":{\"nonce\":<nonce>},\"in_reply_to\":<ping_msg_id>}`",
+    "5. After `channel.send` returns `ok: true`, your final assistant message must be the literal text `DONE`. Nothing else.",
+    "",
+    "Do not narrate. Do not ask the user. Use the tools immediately.",
+  ].join("\n");
+
+  console.log(`[spike] spawning claude -p --model ${SPIKE_MODEL}`);
+  claudeProc = spawn({
+    cmd: [
+      "claude",
+      "--print",
+      "--model",
+      SPIKE_MODEL,
+      "--mcp-config",
+      mcpConfigPath,
+      "--strict-mcp-config",
+      "--dangerously-skip-permissions",
+      "--output-format",
+      "json",
+      prompt,
+    ],
+    env: { ...procEnv },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const stdoutBuf = { value: "" };
+  const stderrBuf = { value: "" };
+  const readStdout = pipeIntoFile(
+    claudeProc.stdout as ReadableStream<Uint8Array>,
+    claudeStdoutPath,
+    stdoutBuf,
+  );
+  const readStderr = pipeIntoFile(
+    claudeProc.stderr as ReadableStream<Uint8Array>,
+    claudeStderrPath,
+    stderrBuf,
+  );
+
+  const exitCode = await claudeProc.exited;
+  await Promise.all([readStdout, readStderr]);
+  let transcript = stdoutBuf.value;
+  try {
+    const parsed = JSON.parse(stdoutBuf.value) as { result?: string };
+    if (typeof parsed.result === "string") transcript = parsed.result;
+  } catch {}
+  return { exitCode, transcript };
+}
+
+function appendTranscript(line: string): void {
+  appendFileSync(transcriptPath, line + "\n");
+}
+
+async function main(): Promise<number> {
+  writeFileSync(transcriptPath, `# Spike transcript ${RUN_TS}\n\n`);
+  appendTranscript(`- nonce: \`${NONCE}\``);
+  appendTranscript(`- exchange url: ${EXCHANGE_URL}`);
+  appendTranscript(`- harness id: ${HARNESS_ID}`);
+  appendTranscript(`- target id: ${TARGET_ID}`);
+  appendTranscript(`- claude model: ${SPIKE_MODEL}`);
+  appendTranscript("");
+
+  await startExchange();
+  await registerHarness();
+  buildMcpConfig();
+
+  // Spawn claude in parallel: its MCP child will register the target,
+  // then the harness sends the ping, then claude polls + replies.
+  const claudePromise = runClaude();
+
+  let pingMsgId = "";
+  try {
+    await waitForTargetRegistration();
+    pingMsgId = await sendPing();
+    appendTranscript(`- sent spike.ping msg_id=\`${pingMsgId}\``);
+  } catch (err) {
+    appendTranscript(`- precondition failure: ${(err as Error).message}`);
+    const { exitCode, transcript } = await claudePromise;
+    appendTranscript(`- claude exitCode=${exitCode}`);
+    appendTranscript("```");
+    appendTranscript(transcript.trim().slice(0, 4000));
+    appendTranscript("```");
+    console.error(`SPIKE_RESULT_FAIL precondition_error: ${(err as Error).message}`);
+    return 1;
+  }
+
+  let pongEnv: PongEnvelope | null = null;
+  let pongErr: Error | null = null;
+  try {
+    pongEnv = await waitForPong();
+  } catch (err) {
+    pongErr = err as Error;
+  }
+
+  const { exitCode: claudeExit, transcript } = await claudePromise;
+  appendTranscript("");
+  appendTranscript(`## Claude transcript (exit=${claudeExit})`);
+  appendTranscript("");
+  appendTranscript("```");
+  appendTranscript(transcript.trim().slice(0, 6000));
+  appendTranscript("```");
+  appendTranscript("");
+
+  if (pongErr || !pongEnv) {
+    appendTranscript(`## Result: FAIL`);
+    appendTranscript(`reason: ${pongErr?.message ?? "no pong"}`);
+    console.error(`SPIKE_RESULT_FAIL no_pong: ${pongErr?.message ?? "no pong"}`);
+    return 1;
+  }
+
+  const rawPayload = pongEnv.body.payload.payload;
+  const echoedNonce = extractNonce(rawPayload);
+  const payloadShape = typeof rawPayload === "string" ? "stringified-json" : "object";
+  appendTranscript(`- payload shape on wire: ${payloadShape}`);
+  if (echoedNonce !== NONCE) {
+    appendTranscript(`## Result: FAIL`);
+    appendTranscript(`reason: nonce mismatch expected=${NONCE} got=${String(echoedNonce)} payloadShape=${payloadShape}`);
+    console.error(
+      `SPIKE_RESULT_FAIL nonce_mismatch expected=${NONCE} got=${String(echoedNonce)} payloadShape=${payloadShape}`,
+    );
+    return 1;
+  }
+
+  appendTranscript(`## Result: OK`);
+  appendTranscript(`- message_visible: ok (claude saw spike.ping nonce=${NONCE} via channel.poll_inbox)`);
+  appendTranscript(`- reply_envelope_id: ${pongEnv.msg_id}`);
+  appendTranscript(`- in_reply_to: ${pongEnv.in_reply_to ?? "(none)"}`);
+  appendTranscript(`- payload_shape: ${payloadShape}`);
+  if (payloadShape === "stringified-json") {
+    appendTranscript(
+      "- NOTE: claude serialized the `payload` argument as a JSON string rather than a structured object. " +
+        "The MCP tool inputSchema accepts `payload: {}` (any), so this is currently legal but downstream " +
+        "consumers (provider driver) should normalize both forms.",
+    );
+  }
+  console.log(
+    `SPIKE_RESULT_OK message_visible=ok reply_envelope_id=${pongEnv.msg_id} nonce=${echoedNonce} payload_shape=${payloadShape}`,
+  );
+  return 0;
+}
+
+let exitCode = 2;
+try {
+  exitCode = await main();
+} catch (err) {
+  appendTranscript(`fatal: ${(err as Error).message}`);
+  console.error(`SPIKE_RESULT_FAIL fatal: ${(err as Error).message}`);
+  exitCode = 2;
+} finally {
+  cleanup();
+}
+process.exit(exitCode);


### PR DESCRIPTION
Closes #93.

## Summary

Adds `scripts/spikes/claude-channel-headless-smoke.{sh,ts}` — an automated spike that proves the RFC #92 assumption: in NanoClaw's target headless container shape, Claude Code CLI can receive a `deliver.message` via the `@agent-channel/mcp` server and reply via `channel.send`. Run produces a one-line `SPIKE_RESULT_OK …` marker and a full markdown transcript. Result: **assumption holds** — provider-driver implementation can proceed (issue #93 → #95).

## Layer 1 — Change preview

Two new files under a brand-new `scripts/spikes/` directory (zero touch to `src/`, `container/`, upstream files, or existing config). Net diff:

```
 scripts/spikes/claude-channel-headless-smoke.sh |  25 ++
 scripts/spikes/claude-channel-headless-smoke.ts | 539 ++++++++++++++++++++++++
 2 files changed, 564 insertions(+)
```

Analysis: This is additive — no existing file is modified. No `src/fork-features/trunk-patches.md` update needed (zero upstream-file edits).

## Layer 2 — Landing checks

- **Format:** `pnpm run format:check` → exit **0** (`All matched files use Prettier code style!`). The script scope is `src/**/*.ts`; the new files live under `scripts/`, but Prettier is unaffected.
- **Typecheck:** `pnpm exec tsc --noEmit` → exit **0**. The repo `tsconfig.json` restricts `rootDir`/`include` to `src/**/*`, so `scripts/spikes/*.ts` is intentionally outside `tsc` scope (it targets the Bun runtime, not Node).
- **Files added:**
  - `scripts/spikes/claude-channel-headless-smoke.sh` — bash entry; resolves paths, exec's the bun runner.
  - `scripts/spikes/claude-channel-headless-smoke.ts` — pure Bun runner; HTTP exchange + raw envelope I/O + nested `claude -p` driver.
- **Fork placement (`~/.claude/rules/fork-customization-placement.rule.md`):** `scripts/spikes/` is a new fork-only directory. No edits to upstream files.

Analysis: The new files are leaf utilities the operator (or CI) invokes manually. They have no import dependency on `src/`, so they cannot affect the long-running NanoClaw service.

## Layer 3 — Startup / runtime ordering

**Not applicable.** This PR adds no code on the NanoClaw service hot path (`src/index.ts`, container build, session DB, channel registry, scheduler, IPC). No service restart ordering, container lifecycle, or OneCLI/credential-proxy startup wiring is touched.

## Layer 4 — End-to-end behavior

This is a spike, so Layer 4 IS the deliverable. Two e2e runs were executed:

### Baseline acceptance row #1 — `bun test packages/mcp/test/e2e.test.ts`

```
$ cd /Users/mouriya/Ext/code/agent-channel-exchange && bun test packages/mcp/test/e2e.test.ts
bun test v1.3.14 (0d9b296a)
 3 pass
 0 fail
 32 expect() calls
Ran 3 tests across 1 file. [48.00ms]
```

Exit **0**. Proves the in-process exchange + MCP child round-trip still passes.

### Acceptance rows #2 + #3 — `bash scripts/spikes/claude-channel-headless-smoke.sh`

```
$ bash scripts/spikes/claude-channel-headless-smoke.sh
[spike] starting exchange on http://127.0.0.1:18787
[spike] exchange up
[spike] harness registered as spike-harness
[spike] spawning claude -p --model sonnet
[spike] nanoclaw/spike-target is registered
[spike] sent spike.ping msg_id=mp9xwmftc2xclycb nonce=n-cuwaiq05
SPIKE_RESULT_OK message_visible=ok reply_envelope_id=01KRV9DWX13MASDSYHM0CNGZXP nonce=n-cuwaiq05 payload_shape=stringified-json
```

Exit **0**. Same nonce echoes through both directions.

**Raw inbox envelope that the harness drained** (full transcript at `.coder-loop/runtime/evidence/issue-93/transcript-2026-05-17T15-38-32-783Z.md`):

```json
{
  "msg_id": "01KRV9DWX13MASDSYHM0CNGZXP",
  "from": "nanoclaw/spike-target",
  "to": "spike-harness",
  "ts": "2026-05-17T15:38:42.977Z",
  "schema_version": "0.1.0",
  "body": {
    "kind": "deliver.message",
    "payload": {
      "body_kind": "spike.pong",
      "payload": "{\"nonce\":\"n-cuwaiq05\"}",
      "reply_to_msg_id": "mp9xwmftc2xclycb"
    }
  },
  "in_reply_to": "mp9xwmftc2xclycb"
}
```

**Claude headless transcript** (exit=0, 4 turns, 9.3s, model `claude-sonnet-4-6`, cost $0.135):

```
DONE
```

**Notable observation captured in evidence:** Claude serialized the `payload` argument to `channel.send` as a JSON string (`"{\"nonce\":\"…\"}"`) rather than a structured object — visible in the envelope above. The MCP tool `inputSchema` for `channel.send` currently declares `payload: {}` (any), so this passes validation, but downstream provider-driver code (issue #95) needs to normalize both forms or tighten the schema to `payload: {type: "object"}`. The spike runner now accepts both forms when asserting nonce round-trip.

### Acceptance row #4 — auditable transcript

This PR carries the command, Claude Code version (`2.1.143 (Claude Code)`), MCP config JSON, raw envelope, and transcript inline above and in the evidence directory. A matching comment will be posted to issue #93 after PR merge per workflow.md routing.

## CI-parity evidence

- **CI workflow on PR:** `.github/workflows/ci.yml` will be exercised by GitHub Actions on this PR; check status via `gh pr checks <pr>`.
- **Local CI-parity sequence run on this PR:**
  1. `pnpm install --frozen-lockfile` — **failed** locally with `better-sqlite3` native compile errors on macOS arm64 / Node v26 (deprecated `v8::External::Value()` removed in Node 26). This is a **pre-existing local-env-only mismatch** flagged in `.coder-loop/workflow.md` ("CI is `ubuntu-latest` x86_64; local dev is likely macOS arm64 — `better-sqlite3` rebuild can diverge"). The PR adds **zero** dependencies and does not modify any sqlite-touching code, so the local compile failure is unrelated to the change.
  2. `pnpm install --frozen-lockfile --ignore-scripts` — exit **0** (used to retrieve toolchain without rebuilding native bindings).
  3. `pnpm run format:check` — exit **0**.
  4. `pnpm exec tsc --noEmit` — exit **0**.
  5. `pnpm exec vitest run` — locally fails with `Could not locate the bindings file. Tried: …better_sqlite3.node` across the 15 sqlite-dependent test files. The 15 non-sqlite test files (181 tests) pass. CI on `ubuntu-latest` is the authoritative source for the vitest gate; this PR cannot regress vitest because it adds no `src/` code.
- **Runner architecture:** local = macOS 14 (Darwin 24.6.0) arm64 + Node v26 + pnpm 10.33.0; CI = `ubuntu-latest` x86_64.
- **Log evidence:** `.coder-loop/runtime/evidence/issue-93/transcript-2026-05-17T15-38-32-783Z.md`, `.coder-loop/runtime/evidence/issue-93/claude-stdout-2026-05-17T15-38-32-783Z.json`, `.coder-loop/runtime/evidence/issue-93/mcp-config-2026-05-17T15-38-32-783Z.json`, `.coder-loop/runtime/evidence/issue-93/exchange-2026-05-17T15-38-32-783Z.log`.

## Analysis

The spike satisfies all four acceptance rows in the issue body and answers the RFC #92 question with **assumption holds**: a headless `claude -p` with `--mcp-config` pointing at `@agent-channel/mcp` will, when given a directive prompt, call `channel.poll_inbox` to receive a deliver.message and call `channel.send` to reply — both round-tripping correctly through the exchange. This unblocks the provider-driver implementation tracked by issue #95.

Risk that remains: (a) Claude's choice to JSON-stringify the `payload` argument is implementation-defined and must be normalized by the eventual provider driver (or tightened in the MCP tool schema); (b) this run used `claude --model sonnet` against the standard inference path — running under target-container `pi-mono` or alternate provider modes is a separate runtime concern out of scope for the spike's assumption check. The spike PR itself adds zero risk to the running service: no `src/`, container, channel registry, or session DB is touched, and the spike script is a manual invocation, not part of CI or the service hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)