### PR TITLE
feat: add channel exchange e2e regression

### DIFF
--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -20,9 +20,9 @@
 import { Database } from 'bun:sqlite';
 import fs from 'fs';
 
-const DEFAULT_INBOUND_PATH = '/workspace/inbound.db';
-const DEFAULT_OUTBOUND_PATH = '/workspace/outbound.db';
-const DEFAULT_HEARTBEAT_PATH = '/workspace/.heartbeat';
+const DEFAULT_INBOUND_PATH = process.env.NANOCLAW_RUNNER_INBOUND_DB || '/workspace/inbound.db';
+const DEFAULT_OUTBOUND_PATH = process.env.NANOCLAW_RUNNER_OUTBOUND_DB || '/workspace/outbound.db';
+const DEFAULT_HEARTBEAT_PATH = process.env.NANOCLAW_RUNNER_HEARTBEAT || '/workspace/.heartbeat';
 
 let _inbound: Database | null = null;
 let _outbound: Database | null = null;
@@ -48,7 +48,11 @@ export function openInboundDb(): Database {
   // so the singleton survives for the rest of the test.
   if (_testMode && _inbound) {
     const db = _inbound;
-    return { prepare: (sql: string) => db.prepare(sql), exec: (sql: string) => db.exec(sql), close: () => {} } as unknown as Database;
+    return {
+      prepare: (sql: string) => db.prepare(sql),
+      exec: (sql: string) => db.exec(sql),
+      close: () => {},
+    } as unknown as Database;
   }
   const db = new Database(DEFAULT_INBOUND_PATH, { readonly: true });
   db.exec('PRAGMA busy_timeout = 5000');

--- a/container/agent-runner/src/providers/claude.test.ts
+++ b/container/agent-runner/src/providers/claude.test.ts
@@ -189,6 +189,32 @@ describe('ClaudeProvider', () => {
     expect(await iter.next()).toEqual({ done: true, value: undefined });
   });
 
+  it('keeps listening for channel.send after advisory rate-limit telemetry', async () => {
+    const { provider, children, exchanges } = makeProvider({ env: { CLAUDE_CODE_EXECUTABLE: 'claude-test' } });
+    const query = provider.query({ prompt: 'hello', cwd: '/workspace/agent' });
+    const iter = query.events[Symbol.asyncIterator]();
+    const child = children[0];
+
+    child.send({ type: 'rate_limit_event' });
+    expect(await nextEvent(iter)).toEqual({ type: 'activity' });
+    expect(await nextEvent(iter)).toEqual({
+      type: 'error',
+      message: 'Rate limit',
+      retryable: false,
+      classification: 'quota',
+    });
+
+    exchanges[0].emitRuntimeMessage('<message to="main">delivered after telemetry</message>');
+    expect(await nextEvent(iter)).toEqual({ type: 'activity' });
+    expect(await nextEvent(iter)).toEqual({
+      type: 'result',
+      text: '<message to="main">delivered after telemetry</message>',
+    });
+
+    child.close();
+    expect(await iter.next()).toEqual({ done: true, value: undefined });
+  });
+
   it('pushes live follow-ups through exchange and only nudges Claude to poll', () => {
     const { provider, children, exchanges } = makeProvider({ env: { CLAUDE_CODE_EXECUTABLE: 'claude-test' } });
     const query = provider.query({ prompt: 'initial', cwd: '/workspace/agent' });

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -290,6 +290,9 @@ export class ClaudeProvider implements AgentProvider {
         child?.stdin.end();
       },
     });
+    log(
+      `Started channel exchange url=${exchange.url} runtimeChannelId=${exchange.runtimeChannelId} claudeChannelId=${exchange.claudeChannelId}`,
+    );
 
     child = this.spawnClaude(resolveClaudeExecutable(this.env), this.buildArgs(input, exchange), {
       cwd: input.cwd,
@@ -321,7 +324,6 @@ export class ClaudeProvider implements AgentProvider {
           return;
         }
         if (event.type === 'rate_limit_event' || (event.type === 'system' && event.subtype === 'rate_limit_event')) {
-          sawTerminalProviderEvent = true;
           queue.push({ type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' });
           return;
         }

--- a/docs/channel-exchange-e2e.md
+++ b/docs/channel-exchange-e2e.md
@@ -1,0 +1,20 @@
+# Channel Exchange E2E
+
+Run the SDK replacement true-path regression with:
+
+```bash
+pnpm run test:e2e:channel-exchange
+```
+
+The slice creates an isolated repo-local NanoClaw data root, writes a real inbound session DB row, runs the real `container/agent-runner` poll loop under Bun with the Claude Code provider, sends the turn through the provider-local channel exchange/MCP server, and drains NanoClaw host delivery back to a target-equivalent channel adapter.
+
+Environment knobs:
+
+- `CLAUDE_CODE_EXECUTABLE`: Claude Code CLI path, default `claude`.
+- `NANOCLAW_E2E_MODEL`: Claude Code model argument, default `sonnet`.
+- `NANOCLAW_E2E_TIMEOUT_MS`: end-to-end timeout, default `300000`.
+- `NANOCLAW_E2E_WORK_DIR`: repo-local working directory, default `.nanoclaw/e2e/channel-exchange`.
+- `NANOCLAW_E2E_EVIDENCE_DIR`: repo-local evidence directory, default inside the run directory.
+- `NANOCLAW_E2E_RUN_ID`: stable run id for evidence filenames.
+
+The command exits `0` only when the expected nonce is delivered through NanoClaw host delivery. Missing tools, Claude Code quota/auth failures, MCP/exchange startup errors, provider exits, and host delivery failures are reported as `CHANNEL_EXCHANGE_E2E_BLOCKED phase=<environment|provider|exchange_mcp|delivery> ...` with a markdown transcript, DB snapshot, and runner logs.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e:channel-exchange": "tsx scripts/e2e/channel-exchange.ts"
   },
   "dependencies": {
     "@clack/core": "^1.2.0",

--- a/scripts/e2e/channel-exchange-runner.ts
+++ b/scripts/e2e/channel-exchange-runner.ts
@@ -1,0 +1,38 @@
+import { buildSystemPromptAddendum } from '../../container/agent-runner/src/destinations.js';
+import { createProvider } from '../../container/agent-runner/src/providers/factory.js';
+import '../../container/agent-runner/src/providers/index.js';
+import { runPollLoop } from '../../container/agent-runner/src/poll-loop.js';
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+const cwd = required('NANOCLAW_E2E_AGENT_CWD');
+const model = process.env.NANOCLAW_E2E_MODEL || 'sonnet';
+const effort = process.env.NANOCLAW_E2E_EFFORT;
+const assistantName = process.env.NANOCLAW_E2E_ASSISTANT_NAME || 'Channel Exchange E2E Agent';
+
+const provider = createProvider('claude', {
+  assistantName,
+  env: { ...process.env },
+  mcpServers: {},
+  model,
+  effort,
+});
+
+const instructions = [
+  'This is an automated NanoClaw channel-exchange e2e run.',
+  'Complete the user request by sending exactly one NanoClaw destination message. Do not leave the response as scratchpad text.',
+  buildSystemPromptAddendum(assistantName),
+].join('\n\n');
+
+await runPollLoop({
+  provider,
+  providerName: 'claude',
+  cwd,
+  systemContext: { instructions },
+});

--- a/scripts/e2e/channel-exchange.ts
+++ b/scripts/e2e/channel-exchange.ts
@@ -1,0 +1,544 @@
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import Database from 'better-sqlite3';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const RUN_TS = new Date().toISOString().replace(/[:.]/g, '-');
+const RUN_ID = process.env.NANOCLAW_E2E_RUN_ID || RUN_TS;
+const WORK_ROOT = path.resolve(
+  process.env.NANOCLAW_E2E_WORK_DIR || path.join(REPO_ROOT, '.nanoclaw/e2e/channel-exchange'),
+);
+const RUN_DIR = path.join(WORK_ROOT, `run-${RUN_ID}`);
+const EVIDENCE_DIR = path.resolve(process.env.NANOCLAW_E2E_EVIDENCE_DIR || path.join(RUN_DIR, 'evidence'));
+const LOG_DIR = path.join(EVIDENCE_DIR, 'logs');
+const TRANSCRIPT_PATH = path.join(EVIDENCE_DIR, `channel-exchange-${RUN_ID}.md`);
+const SUMMARY_PATH = path.join(EVIDENCE_DIR, `channel-exchange-${RUN_ID}.json`);
+const RUNNER_STDOUT = path.join(LOG_DIR, 'agent-runner.stdout.log');
+const RUNNER_STDERR = path.join(LOG_DIR, 'agent-runner.stderr.log');
+const DB_SNAPSHOT = path.join(EVIDENCE_DIR, `db-snapshot-${RUN_ID}.json`);
+const TIMEOUT_MS = Number(process.env.NANOCLAW_E2E_TIMEOUT_MS || '300000');
+const CLAUDE_CODE_EXECUTABLE = process.env.CLAUDE_CODE_EXECUTABLE || 'claude';
+const MODEL = process.env.NANOCLAW_E2E_MODEL || 'sonnet';
+const CHANNEL_TYPE = 'channel-exchange-e2e';
+const PLATFORM_ID = 'target-equivalent-channel';
+const DESTINATION_NAME = 'e2e-channel';
+const AGENT_GROUP_ID = 'ag-channel-exchange-e2e';
+const MESSAGING_GROUP_ID = 'mg-channel-exchange-e2e';
+const SESSION_MESSAGE_ID = 'msg-channel-exchange-e2e-1';
+const NONCE = `n-${Math.random().toString(36).slice(2, 10)}`;
+const EXPECTED_TEXT = `CHANNEL_EXCHANGE_E2E_OK nonce=${NONCE}`;
+
+interface Session {
+  id: string;
+  agent_group_id: string;
+  messaging_group_id: string | null;
+  thread_id: string | null;
+  agent_provider: string | null;
+  status: string;
+  container_status: string;
+  last_active: string | null;
+  created_at: string;
+}
+
+interface DeliveredMessage {
+  channelType: string;
+  platformId: string;
+  threadId: string | null;
+  kind: string;
+  content: unknown;
+  contentText: string;
+  platformMessageId: string;
+}
+
+class E2EFailure extends Error {
+  constructor(
+    readonly phase: string,
+    message: string,
+    readonly exitCode = 1,
+  ) {
+    super(message);
+  }
+}
+
+function assertRepoLocal(targetPath: string, label: string): void {
+  const rel = path.relative(REPO_ROOT, targetPath);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new E2EFailure('environment', `${label} must be inside repo root: ${targetPath}`, 2);
+  }
+  if (targetPath === '/tmp' || targetPath.startsWith('/tmp/')) {
+    throw new E2EFailure('environment', `${label} must not be under /tmp: ${targetPath}`, 2);
+  }
+}
+
+function appendTranscript(line = ''): void {
+  fs.appendFileSync(TRANSCRIPT_PATH, `${line}\n`);
+}
+
+function commandVersion(command: string, args: string[]): { ok: true; text: string } | { ok: false; text: string } {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  const text = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+  if (result.status === 0) return { ok: true, text };
+  return { ok: false, text: text || result.error?.message || `exit ${result.status ?? 'unknown'}` };
+}
+
+async function importRepoModule<T>(relativePath: string): Promise<T> {
+  return (await import(pathToFileURL(path.join(REPO_ROOT, relativePath)).href)) as T;
+}
+
+function rowSnapshot(dbPath: string, table: string): unknown[] {
+  if (!fs.existsSync(dbPath)) return [];
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare(`SELECT * FROM ${table}`).all();
+  } finally {
+    db.close();
+  }
+}
+
+function writeSnapshot(paths: { inboundDb: string; outboundDb: string }, delivered: DeliveredMessage[]): void {
+  fs.writeFileSync(
+    DB_SNAPSHOT,
+    JSON.stringify(
+      {
+        inboundDb: paths.inboundDb,
+        outboundDb: paths.outboundDb,
+        messages_in: rowSnapshot(paths.inboundDb, 'messages_in'),
+        delivered_rows: rowSnapshot(paths.inboundDb, 'delivered'),
+        destinations: rowSnapshot(paths.inboundDb, 'destinations'),
+        session_routing: rowSnapshot(paths.inboundDb, 'session_routing'),
+        messages_out: rowSnapshot(paths.outboundDb, 'messages_out'),
+        processing_ack: rowSnapshot(paths.outboundDb, 'processing_ack'),
+        delivered,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function parseContent(content: string): { text?: string } {
+  try {
+    const parsed = JSON.parse(content) as { text?: unknown };
+    return { text: typeof parsed.text === 'string' ? parsed.text : undefined };
+  } catch {
+    return { text: content };
+  }
+}
+
+function pipeToFile(stream: NodeJS.ReadableStream, filePath: string): void {
+  const dest = fs.createWriteStream(filePath);
+  stream.pipe(dest);
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function classifyRunnerFailure(stderr: string, outboundRows: unknown[]): E2EFailure {
+  const messagesOut = outboundRows as Array<{ content?: string }>;
+  const errorRow = messagesOut.find((row) => {
+    const text = typeof row.content === 'string' ? parseContent(row.content).text : undefined;
+    return text?.startsWith('Error:');
+  });
+  if (errorRow?.content) {
+    const text = parseContent(errorRow.content).text || errorRow.content;
+    if (/rate limit|quota/i.test(text)) {
+      return new E2EFailure('provider', `Claude Code quota/rate-limit blocker: ${text}`);
+    }
+    return new E2EFailure('provider', text);
+  }
+  if (/agent-channel-mcp.*startup error|AGENT_CHANNEL_EXCHANGE_URL|fetch failed|ECONNREFUSED/i.test(stderr)) {
+    return new E2EFailure('exchange_mcp', stderr.trim().split('\n').slice(-6).join('\n'));
+  }
+  if (/Claude Code exited without replying through channel\.send/i.test(stderr)) {
+    return new E2EFailure('provider', 'Claude Code exited without replying through channel.send');
+  }
+  return new E2EFailure('provider', stderr.trim().split('\n').slice(-8).join('\n') || 'agent runner exited');
+}
+
+function cleanupRunner(runner: ChildProcessWithoutNullStreams | null): void {
+  if (!runner || runner.exitCode !== null || runner.killed) return;
+  runner.kill('SIGTERM');
+}
+
+async function main(): Promise<number> {
+  assertRepoLocal(WORK_ROOT, 'NANOCLAW_E2E_WORK_DIR');
+  assertRepoLocal(EVIDENCE_DIR, 'NANOCLAW_E2E_EVIDENCE_DIR');
+  fs.rmSync(RUN_DIR, { recursive: true, force: true });
+  fs.mkdirSync(RUN_DIR, { recursive: true });
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  fs.writeFileSync(
+    TRANSCRIPT_PATH,
+    [
+      `# Channel exchange e2e ${RUN_ID}`,
+      '',
+      `- repo root: ${REPO_ROOT}`,
+      `- run dir: ${RUN_DIR}`,
+      `- evidence dir: ${EVIDENCE_DIR}`,
+      `- channel type: ${CHANNEL_TYPE}`,
+      `- platform id: ${PLATFORM_ID}`,
+      `- destination: ${DESTINATION_NAME}`,
+      `- nonce: ${NONCE}`,
+      `- timeout ms: ${TIMEOUT_MS}`,
+      '',
+    ].join('\n'),
+  );
+
+  const bunVersion = commandVersion('bun', ['--version']);
+  const claudeVersion = commandVersion(CLAUDE_CODE_EXECUTABLE, ['--version']);
+  const pnpmVersion = commandVersion('pnpm', ['--version']);
+  appendTranscript('## Environment');
+  appendTranscript(`- node: ${process.version}`);
+  appendTranscript(`- platform: ${process.platform}/${process.arch}`);
+  appendTranscript(`- pnpm: ${pnpmVersion.ok ? pnpmVersion.text : `missing (${pnpmVersion.text})`}`);
+  appendTranscript(`- bun: ${bunVersion.ok ? bunVersion.text : `missing (${bunVersion.text})`}`);
+  appendTranscript(`- claude executable: ${CLAUDE_CODE_EXECUTABLE}`);
+  appendTranscript(`- claude version: ${claudeVersion.ok ? claudeVersion.text : `missing (${claudeVersion.text})`}`);
+  appendTranscript(`- model: ${MODEL}`);
+  appendTranscript('');
+
+  if (!bunVersion.ok) throw new E2EFailure('environment', `bun unavailable: ${bunVersion.text}`, 2);
+  if (!claudeVersion.ok) throw new E2EFailure('environment', `Claude Code CLI unavailable: ${claudeVersion.text}`, 2);
+
+  process.chdir(RUN_DIR);
+
+  const { initDb, closeDb } = await importRepoModule<{
+    initDb(dbPath: string): Database.Database;
+    closeDb(): void;
+  }>('src/db/connection.ts');
+  const { runMigrations } = await importRepoModule<{ runMigrations(db: Database.Database): void }>(
+    'src/db/migrations/index.ts',
+  );
+  const { createAgentGroup } = await importRepoModule<{
+    createAgentGroup(group: {
+      id: string;
+      name: string;
+      folder: string;
+      agent_provider: string | null;
+      created_at: string;
+    }): void;
+  }>('src/db/agent-groups.ts');
+  const { createMessagingGroup, createMessagingGroupAgent } = await importRepoModule<{
+    createMessagingGroup(group: {
+      id: string;
+      channel_type: string;
+      platform_id: string;
+      name: string | null;
+      is_group: 0 | 1;
+      unknown_sender_policy: string;
+      created_at: string;
+    }): void;
+    createMessagingGroupAgent(agent: {
+      id: string;
+      messaging_group_id: string;
+      agent_group_id: string;
+      engage_mode: string;
+      engage_pattern: string | null;
+      sender_scope: string;
+      ignored_message_policy: string;
+      session_mode: string;
+      priority: number;
+      created_at: string;
+    }): void;
+  }>('src/db/messaging-groups.ts');
+  const { resolveSession, writeSessionMessage, inboundDbPath, outboundDbPath, writeSessionRouting } =
+    await importRepoModule<{
+      resolveSession(
+        agentGroupId: string,
+        messagingGroupId: string | null,
+        threadId: string | null,
+        sessionMode: 'shared' | 'per-thread' | 'agent-shared',
+      ): { session: Session; created: boolean };
+      writeSessionMessage(
+        agentGroupId: string,
+        sessionId: string,
+        message: {
+          id: string;
+          kind: string;
+          timestamp: string;
+          platformId?: string | null;
+          channelType?: string | null;
+          threadId?: string | null;
+          content: string;
+          trigger?: 0 | 1;
+        },
+      ): void;
+      inboundDbPath(agentGroupId: string, sessionId: string): string;
+      outboundDbPath(agentGroupId: string, sessionId: string): string;
+      writeSessionRouting(agentGroupId: string, sessionId: string): void;
+    }>('src/session-manager.ts');
+  const { openInboundDb: openHostInboundDb, replaceDestinations } = await importRepoModule<{
+    openInboundDb(dbPath: string): Database.Database;
+    replaceDestinations(
+      db: Database.Database,
+      entries: Array<{
+        name: string;
+        display_name: string | null;
+        type: 'channel' | 'agent';
+        channel_type: string | null;
+        platform_id: string | null;
+        agent_group_id: string | null;
+      }>,
+    ): void;
+  }>('src/db/session-db.ts');
+  const { setDeliveryAdapter, deliverSessionMessages, stopDeliveryPolls } = await importRepoModule<{
+    setDeliveryAdapter(adapter: {
+      deliver(
+        channelType: string,
+        platformId: string,
+        threadId: string | null,
+        kind: string,
+        content: string,
+      ): Promise<string | undefined>;
+    }): void;
+    deliverSessionMessages(session: Session): Promise<void>;
+    stopDeliveryPolls(): void;
+  }>('src/delivery.ts');
+
+  const now = new Date().toISOString();
+  const centralDbPath = path.join(RUN_DIR, 'data', 'nanoclaw-e2e.db');
+  const db = initDb(centralDbPath);
+  runMigrations(db);
+
+  const agentFolder = 'channel-exchange-e2e-agent';
+  const agentDir = path.join(RUN_DIR, 'groups', agentFolder);
+  fs.mkdirSync(agentDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(agentDir, 'CLAUDE.md'),
+    [
+      '# Channel Exchange E2E Agent',
+      '',
+      `For the e2e request, send exactly <message to="${DESTINATION_NAME}">${EXPECTED_TEXT}</message>.`,
+      'Do not add scratchpad text outside the message block.',
+      '',
+    ].join('\n'),
+  );
+
+  createAgentGroup({
+    id: AGENT_GROUP_ID,
+    name: 'Channel Exchange E2E Agent',
+    folder: agentFolder,
+    agent_provider: 'claude',
+    created_at: now,
+  });
+  createMessagingGroup({
+    id: MESSAGING_GROUP_ID,
+    channel_type: CHANNEL_TYPE,
+    platform_id: PLATFORM_ID,
+    name: 'Channel Exchange E2E',
+    is_group: 0,
+    unknown_sender_policy: 'public',
+    created_at: now,
+  });
+  createMessagingGroupAgent({
+    id: 'mga-channel-exchange-e2e',
+    messaging_group_id: MESSAGING_GROUP_ID,
+    agent_group_id: AGENT_GROUP_ID,
+    engage_mode: 'pattern',
+    engage_pattern: '.',
+    sender_scope: 'all',
+    ignored_message_policy: 'drop',
+    session_mode: 'shared',
+    priority: 0,
+    created_at: now,
+  });
+
+  const { session } = resolveSession(AGENT_GROUP_ID, MESSAGING_GROUP_ID, null, 'shared');
+  writeSessionRouting(AGENT_GROUP_ID, session.id);
+  const inboundDb = inboundDbPath(AGENT_GROUP_ID, session.id);
+  const outboundDb = outboundDbPath(AGENT_GROUP_ID, session.id);
+  const hostInbound = openHostInboundDb(inboundDb);
+  try {
+    replaceDestinations(hostInbound, [
+      {
+        name: DESTINATION_NAME,
+        display_name: 'E2E Channel',
+        type: 'channel',
+        channel_type: CHANNEL_TYPE,
+        platform_id: PLATFORM_ID,
+        agent_group_id: null,
+      },
+    ]);
+  } finally {
+    hostInbound.close();
+  }
+  writeSessionMessage(AGENT_GROUP_ID, session.id, {
+    id: SESSION_MESSAGE_ID,
+    kind: 'chat',
+    timestamp: now,
+    channelType: CHANNEL_TYPE,
+    platformId: PLATFORM_ID,
+    threadId: null,
+    trigger: 1,
+    content: JSON.stringify({
+      sender: 'Channel Exchange E2E',
+      senderId: 'channel-exchange-e2e:user',
+      text: `Reply exactly with <message to="${DESTINATION_NAME}">${EXPECTED_TEXT}</message>. Nothing else.`,
+    }),
+  });
+
+  appendTranscript('## Runtime paths');
+  appendTranscript(`- central db: ${centralDbPath}`);
+  appendTranscript(`- inbound db: ${inboundDb}`);
+  appendTranscript(`- outbound db: ${outboundDb}`);
+  appendTranscript(`- agent cwd: ${agentDir}`);
+  appendTranscript('');
+
+  const delivered: DeliveredMessage[] = [];
+  setDeliveryAdapter({
+    async deliver(channelType, platformId, threadId, kind, content) {
+      const parsed = parseContent(content);
+      const platformMessageId = `e2e-delivery-${delivered.length + 1}`;
+      delivered.push({
+        channelType,
+        platformId,
+        threadId,
+        kind,
+        content: JSON.parse(content) as unknown,
+        contentText: parsed.text ?? content,
+        platformMessageId,
+      });
+      return platformMessageId;
+    },
+  });
+
+  const runner = spawn('bun', ['run', path.join(REPO_ROOT, 'scripts/e2e/channel-exchange-runner.ts')], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      NANOCLAW_RUNNER_INBOUND_DB: inboundDb,
+      NANOCLAW_RUNNER_OUTBOUND_DB: outboundDb,
+      NANOCLAW_RUNNER_HEARTBEAT: path.join(path.dirname(inboundDb), '.heartbeat'),
+      NANOCLAW_E2E_AGENT_CWD: agentDir,
+      NANOCLAW_E2E_MODEL: MODEL,
+      CLAUDE_CODE_EXECUTABLE,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  pipeToFile(runner.stdout, RUNNER_STDOUT);
+  pipeToFile(runner.stderr, RUNNER_STDERR);
+
+  let failure: E2EFailure | null = null;
+  try {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < TIMEOUT_MS) {
+      await deliverSessionMessages(session);
+      if (delivered.some((msg) => msg.contentText.includes(EXPECTED_TEXT))) {
+        writeSnapshot({ inboundDb, outboundDb }, delivered);
+        appendTranscript('## Result');
+        appendTranscript(
+          `CHANNEL_EXCHANGE_E2E_OK nonce=${NONCE} delivered=${delivered.length} inboundDb=${inboundDb} outboundDb=${outboundDb}`,
+        );
+        appendTranscript('');
+        appendTranscript('## Delivered messages');
+        appendTranscript('```json');
+        appendTranscript(JSON.stringify(delivered, null, 2));
+        appendTranscript('```');
+        fs.writeFileSync(
+          SUMMARY_PATH,
+          JSON.stringify(
+            {
+              ok: true,
+              runId: RUN_ID,
+              nonce: NONCE,
+              expectedText: EXPECTED_TEXT,
+              channelType: CHANNEL_TYPE,
+              claudeVersion: claudeVersion.text,
+              model: MODEL,
+              inboundDb,
+              outboundDb,
+              runnerStdout: RUNNER_STDOUT,
+              runnerStderr: RUNNER_STDERR,
+              dbSnapshot: DB_SNAPSHOT,
+              delivered,
+            },
+            null,
+            2,
+          ),
+        );
+        console.log(
+          `CHANNEL_EXCHANGE_E2E_OK nonce=${NONCE} delivered=${delivered.length} transcript=${TRANSCRIPT_PATH}`,
+        );
+        return 0;
+      }
+      if (runner.exitCode !== null) {
+        failure = classifyRunnerFailure(
+          fs.readFileSync(RUNNER_STDERR, 'utf8'),
+          rowSnapshot(outboundDb, 'messages_out'),
+        );
+        break;
+      }
+      await wait(1000);
+    }
+    if (!failure) {
+      const stderr = fs.existsSync(RUNNER_STDERR) ? fs.readFileSync(RUNNER_STDERR, 'utf8') : '';
+      const outRows = rowSnapshot(outboundDb, 'messages_out');
+      if (outRows.length > 0) {
+        failure = new E2EFailure(
+          'delivery',
+          `outbound rows exist but expected message was not delivered; rows=${outRows.length}`,
+        );
+      } else if (/Started channel exchange/.test(stderr) || /agent-channel-mcp/.test(stderr)) {
+        failure = new E2EFailure(
+          'exchange_mcp',
+          `runner stayed alive but no provider result reached outbound.db within ${TIMEOUT_MS}ms`,
+        );
+      } else {
+        failure = new E2EFailure('provider', `no provider result within ${TIMEOUT_MS}ms`);
+      }
+    }
+    throw failure;
+  } finally {
+    cleanupRunner(runner);
+    stopDeliveryPolls();
+    closeDb();
+    writeSnapshot({ inboundDb, outboundDb }, delivered);
+  }
+}
+
+let exitCode = 1;
+try {
+  exitCode = await main();
+} catch (err) {
+  const failure =
+    err instanceof E2EFailure ? err : new E2EFailure('fatal', err instanceof Error ? err.message : String(err), 2);
+  appendTranscript('## Result');
+  appendTranscript(
+    `CHANNEL_EXCHANGE_E2E_BLOCKED phase=${failure.phase} reason=${JSON.stringify(failure.message)} transcript=${TRANSCRIPT_PATH}`,
+  );
+  appendTranscript('');
+  appendTranscript('## Runner stderr tail');
+  appendTranscript('```');
+  if (fs.existsSync(RUNNER_STDERR)) {
+    appendTranscript(fs.readFileSync(RUNNER_STDERR, 'utf8').trim().split('\n').slice(-40).join('\n'));
+  }
+  appendTranscript('```');
+  fs.writeFileSync(
+    SUMMARY_PATH,
+    JSON.stringify(
+      {
+        ok: false,
+        runId: RUN_ID,
+        phase: failure.phase,
+        reason: failure.message,
+        nonce: NONCE,
+        expectedText: EXPECTED_TEXT,
+        transcript: TRANSCRIPT_PATH,
+        runnerStdout: RUNNER_STDOUT,
+        runnerStderr: RUNNER_STDERR,
+        dbSnapshot: DB_SNAPSHOT,
+      },
+      null,
+      2,
+    ),
+  );
+  console.error(
+    `CHANNEL_EXCHANGE_E2E_BLOCKED phase=${failure.phase} reason=${JSON.stringify(failure.message)} transcript=${TRANSCRIPT_PATH}`,
+  );
+  exitCode = failure.exitCode;
+}
+
+process.exit(exitCode);

--- a/src/fork-features/trunk-patches.md
+++ b/src/fork-features/trunk-patches.md
@@ -56,3 +56,17 @@ When rebasing onto a new upstream version:
 - Patch:
   - Add provider-level tests for channel MCP config construction, exchange-envelope delivery, init/progress/activity mapping, `channel.send` result mapping, live follow-up delivery, abort, and stale-session classification.
 - Why a patch and not pure fork-features: these tests cover the replacement behavior of the built-in `claude` provider and need to live beside the provider test suite.
+
+## Channel exchange e2e harness (issue Mouriya-Emma/nanoclaw#96)
+
+### `container/agent-runner/src/db/connection.ts` — file-backed runner DB override
+
+- Patch:
+  - Let `NANOCLAW_RUNNER_INBOUND_DB`, `NANOCLAW_RUNNER_OUTBOUND_DB`, and `NANOCLAW_RUNNER_HEARTBEAT` override the container defaults `/workspace/inbound.db`, `/workspace/outbound.db`, and `/workspace/.heartbeat`.
+- Why a patch and not pure fork-features: the agent-runner DB paths are module-level constants inside the container-owned DB connection layer. The e2e harness needs to run the real poll-loop and Claude provider against real file-backed session DBs from a repo-local target-equivalent environment, but upstream has no constructor/config hook for runner DB paths outside the `/workspace` container mount.
+
+### `container/agent-runner/src/providers/claude.ts` — exchange endpoint diagnostic
+
+- Patch:
+  - Log the provider-local channel exchange URL plus runtime and Claude channel ids when a query starts.
+- Why a patch and not pure fork-features: the provider creates the exchange internally and currently exposes no observable endpoint metadata. The #96 true-path regression must preserve evidence that distinguishes exchange/MCP/provider/delivery breakpoints, so the diagnostic needs to live at the provider-owned creation point.


### PR DESCRIPTION
Closes #96.

## Summary

Adds `pnpm run test:e2e:channel-exchange`, a repo-local true-path regression that writes a real NanoClaw session DB row, runs the real agent-runner poll loop with the Claude Code channel provider, sends through the provider-local exchange/MCP channel, and verifies NanoClaw host delivery. Also keeps the provider listening after advisory Claude `rate_limit_event` telemetry so a later `channel.send` can still complete the turn, which the new e2e observed in the live run.

## Layer 1 — Change preview

Not applicable — this is a code, test harness, and documentation change with no declarative dry-run target such as a migration plan or infra diff.

Change preview from the committed diff:

```text
container/agent-runner/src/db/connection.ts        |  12 +-
container/agent-runner/src/providers/claude.test.ts |  26 +
container/agent-runner/src/providers/claude.ts      |   4 +-
docs/channel-exchange-e2e.md                       |  20 +
package.json                                       |   3 +-
scripts/e2e/channel-exchange-runner.ts             |  38 ++
scripts/e2e/channel-exchange.ts                    | 544 +++++++++++++++++++++
src/fork-features/trunk-patches.md                 |  14 +
```

Analysis: the diff is scoped to the #96 e2e slice, its provider regression fix, and the required fork trunk-patch tracking for the runner DB-path hook and exchange diagnostics.

## Layer 2 — Landing checks

On-disk checks:

- `package.json` now exposes `test:e2e:channel-exchange` as `tsx scripts/e2e/channel-exchange.ts`.
- `docs/channel-exchange-e2e.md` documents command usage and the required/optional environment variables.
- `container/agent-runner/src/db/connection.ts` accepts `NANOCLAW_RUNNER_INBOUND_DB`, `NANOCLAW_RUNNER_OUTBOUND_DB`, and `NANOCLAW_RUNNER_HEARTBEAT`, allowing the real runner to target file-backed session DBs outside `/workspace` for this regression.
- `container/agent-runner/src/providers/claude.test.ts` adds coverage that advisory `rate_limit_event` telemetry does not suppress a later `channel.send` provider result.
- `src/fork-features/trunk-patches.md` records both direct upstream-file touches.

Local CI/evidence commands were run on Darwin arm64 using Node `v22.22.3` via `mise`, pnpm `10.33.0`, and Bun `1.3.14`. GitHub CI is configured in `.github/workflows/ci.yml` for `ubuntu-latest` with Node 20 and Bun 1.3.12; PR checks had not run yet at PR creation time.

```text
pnpm install --frozen-lockfile                         -> exit 1 on default Node v26 (better-sqlite3 V8 API mismatch)
mise exec node@22 -- pnpm install --frozen-lockfile     -> exit 0
mise exec node@22 -- pnpm rebuild better-sqlite3        -> exit 0
mise exec node@22 -- pnpm run format:check              -> exit 0
mise exec node@22 -- pnpm exec tsc --noEmit             -> exit 0
mise exec node@22 -- pnpm exec tsc -p container/agent-runner/tsconfig.json --noEmit -> exit 0
mise exec node@22 -- pnpm exec vitest run               -> exit 0, 31 files / 338 tests
cd container/agent-runner && bun install --frozen-lockfile -> exit 0
cd container/agent-runner && bun test                   -> exit 0, 99 pass / 0 fail
cd /Users/mouriya/Ext/code/agent-channel-exchange && bun test -> exit 0, 117 pass / 0 fail
mise exec node@22 -- pnpm run build                     -> exit 0
```

Log evidence is under `.coder-loop/runtime/evidence/issue-96/commands/`, including `pnpm-vitest-run-node22.log`, `container-agent-runner-bun-test-final.log`, `agent-channel-exchange-bun-test.log`, and `pnpm-e2e-channel-exchange-node22.log`. The default Node v26 install failure is recorded in `pnpm-install-frozen.log`; it is a local native-addon toolchain mismatch, while the Node 22 install/rebuild path produced a working `better-sqlite3` binding.

## Layer 3 — Startup / runtime ordering

No long-running NanoClaw service restart or deployment ordering is touched. The e2e itself verifies runtime startup order by spawning the agent-runner, starting the provider-local exchange, registering the Claude Code channel MCP child, processing the session row, and then draining host delivery.

Runner stderr from `.coder-loop/runtime/evidence/issue-96/e2e/logs/agent-runner.stderr.log`:

```text
[poll-loop] Processing 1 message(s), kinds: chat
[claude-provider] Started channel exchange url=http://127.0.0.1:64307 runtimeChannelId=nanoclaw/agent-runner/1191c21e-2d3e-446e-b723-7e001d20dd71 claudeChannelId=claude-code/1191c21e-2d3e-446e-b723-7e001d20dd71
[poll-loop] Session: b26abec4-1956-453e-90df-02193e9b490b
[poll-loop] Progress: Using ToolSearch
[poll-loop] Error: Rate limit (retryable: false, quota)
[poll-loop] Progress: Using mcp__agent-channel__channel_poll_inbox
[poll-loop] Progress: Using mcp__agent-channel__channel_send
[poll-loop] Result: <message to="e2e-channel">CHANNEL_EXCHANGE_E2E_OK nonce=n-qgvsng3n</message>
```

Analysis: this proves the provider-local exchange endpoint was created before Claude tool use, Claude reached both channel MCP tools, and advisory quota telemetry no longer prevents the later `channel.send` result from reaching the poll loop.

Local `act` CI reproduction was attempted with the detected workflow/job/event and native arm64 container architecture:

```text
act pull_request -W .github/workflows/ci.yml -j ci --container-architecture linux/arm64 -P ubuntu-latest=catthehacker/ubuntu:act-latest -> exit 1
failed to connect to the docker API at unix:///Users/mouriya/.orbstack/run/docker.sock: no such file or directory
```

Analysis: local `act` is blocked by the unavailable OrbStack Docker socket, so the local command sequence above is the CI-parity evidence for this iteration; remote GitHub PR checks should still run after PR creation.

## Layer 4 — End-to-end behavior

Positive path, real/target-equivalent channel-exchange regression:

```text
NANOCLAW_E2E_WORK_DIR=.coder-loop/runtime/evidence/issue-96/e2e-work \
NANOCLAW_E2E_EVIDENCE_DIR=.coder-loop/runtime/evidence/issue-96/e2e \
NANOCLAW_E2E_RUN_ID=run-2026-05-17-18-56-35-313-issue-96 \
mise exec node@22 -- pnpm run test:e2e:channel-exchange

CHANNEL_EXCHANGE_E2E_OK nonce=n-qgvsng3n delivered=1 transcript=.coder-loop/runtime/evidence/issue-96/e2e/channel-exchange-run-2026-05-17-18-56-35-313-issue-96.md
```

DB snapshot from `.coder-loop/runtime/evidence/issue-96/e2e/db-snapshot-run-2026-05-17-18-56-35-313-issue-96.json`:

```json
{
  "messages_in": [{ "id": "msg-channel-exchange-e2e-1", "seq": 2, "channel_type": "channel-exchange-e2e", "platform_id": "target-equivalent-channel", "trigger": 1 }],
  "processing_ack": [{ "message_id": "msg-channel-exchange-e2e-1", "status": "completed" }],
  "messages_out": [{ "seq": 3, "in_reply_to": "msg-channel-exchange-e2e-1", "channel_type": "channel-exchange-e2e", "platform_id": "target-equivalent-channel", "content": "{\"text\":\"CHANNEL_EXCHANGE_E2E_OK nonce=n-qgvsng3n\"}" }],
  "delivered_rows": [{ "message_out_id": "msg-1779045303469-k1li9x", "platform_message_id": "e2e-delivery-1", "status": "delivered" }]
}
```

Negative/environment blocker path:

```text
CLAUDE_CODE_EXECUTABLE=.coder-loop/runtime/evidence/issue-96/missing-claude \
mise exec node@22 -- pnpm run test:e2e:channel-exchange

CHANNEL_EXCHANGE_E2E_BLOCKED phase=environment reason="Claude Code CLI unavailable: spawnSync ... ENOENT"
```

Analysis: the positive run covers external/target-equivalent channel input -> NanoClaw session DB -> agent-runner -> provider-local exchange -> Claude Code channel MCP -> exchange -> `messages_out` -> NanoClaw host delivery. The negative run proves missing runtime dependencies are surfaced as explicit blocker phases rather than silently waived. Browser screenshot evidence is not applicable because NanoClaw is a backend/CLI service and the repo workflow defines Layer 4 for this project as integration/e2e command evidence, not browser screenshots.

## Analysis

The observed nonce `n-qgvsng3n` moved through the full channel exchange path and was delivered through NanoClaw host delivery with `processing_ack=completed`, `messages_out.seq=3`, and a delivered row for `e2e-delivery-1`, satisfying issue #96's true-path regression requirement. The live run also exposed and verified the provider fix for advisory rate-limit telemetry: the stream logged a quota event, then still accepted the later `channel.send` result. The remaining risk is that this run uses a target-equivalent local channel adapter rather than live Mattermost/Telegram, but it intentionally keeps the critical path real: file-backed NanoClaw DBs, real agent-runner poll loop, real Claude Code CLI, real channel MCP, real provider-local exchange, and real NanoClaw delivery.
