### PR TITLE
fix: route CI through vctcn runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, vctcn]
+    container:
+      image: catthehacker/ubuntu:full-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,6 +111,17 @@ jobs:
             pnpm-workspace.yaml
           retention-days: 1
 
+  deploy-tools:
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, vctcn]
+    steps:
+      - name: Verify deploy tools
+        run: |
+          command -v ssh
+          command -v ssh-keyscan
+          command -v rsync
+
   deploy:
     needs: build
     if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,16 @@
 name: deploy
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'container/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.json'
+      - '.github/workflows/deploy.yml'
   push:
     branches: [main]
     paths:
@@ -13,8 +23,9 @@ on:
       - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
-# Pattern A (per Mouriya-Emma/local-cicd-demo §Deployment patterns):
-# build on a github-hosted runner, deploy on the netbird-mesh runner.
+# Pattern A (per local-cicd §Deployment patterns):
+# build on the vctcn runner in an ubuntu-latest-compatible job container,
+# deploy on the netbird-mesh runner.
 # The deploy step rsyncs dist/ + container/ to
 # deploy@nanoclaw-108-124.mouriya.lan then `sudo systemctl restart nanoclaw`
 # and a smoke check.
@@ -42,8 +53,10 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'Mouriya-Emma/nanoclaw'
-    runs-on: ubuntu-latest
+    if: github.repository == 'mouriya-s-lab/nanoclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, linux, vctcn]
+    container:
+      image: catthehacker/ubuntu:full-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -100,6 +113,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, linux, vctcn]
     timeout-minutes: 10
     steps:
@@ -136,6 +150,12 @@ jobs:
           find container/agent-runner container/pi-runner container/skills scripts/ \
             -type f \( -name '*.sh' -o -name '*.mjs' \) -print0 2>/dev/null \
             | xargs -0r chmod +x
+
+      - name: Verify deploy tools
+        run: |
+          command -v ssh
+          command -v ssh-keyscan
+          command -v rsync
 
       - name: Stage SSH key
         env:

--- a/src/fork-features/trunk-patches.md
+++ b/src/fork-features/trunk-patches.md
@@ -70,3 +70,13 @@ When rebasing onto a new upstream version:
 - Patch:
   - Log the provider-local channel exchange URL plus runtime and Claude channel ids when a query starts.
 - Why a patch and not pure fork-features: the provider creates the exchange internally and currently exposes no observable endpoint metadata. The #96 true-path regression must preserve evidence that distinguishes exchange/MCP/provider/delivery breakpoints, so the diagnostic needs to live at the provider-owned creation point.
+
+## vctcn self-hosted CI runner routing (issue mouriya-s-lab/nanoclaw#103)
+
+### `.github/workflows/ci.yml` — CI job runner stanza
+
+- Patch:
+  - Change the PR CI job from `runs-on: ubuntu-latest` to `[self-hosted, linux, vctcn]`.
+  - Run the job inside `catthehacker/ubuntu:full-24.04` so Node, pnpm, Bun, TypeScript, Vitest, and Bun tests execute in an ubuntu-latest-compatible userspace.
+  - Guard the job to same-repository pull requests, because this public fork must not execute untrusted fork PR code on the vctcn self-hosted runner.
+- Why a patch and not pure fork-features: GitHub Actions runner routing is defined only in the upstream-owned workflow file. There is no project extension point that can override a job's runner labels or container image from `src/fork-features/`.


### PR DESCRIPTION
Closes #103.

## Summary

Route NanoClaw's fork CI and deploy build jobs from `ubuntu-latest` to the vctcn self-hosted runner using the `catthehacker/ubuntu:full-24.04` job container. Keep the production deploy job host-side, add an explicit `rsync`/SSH tool check before deploy, and guard self-hosted PR jobs to same-repository pull requests because this repository is public.

## Layer 1 — Change preview

- `git diff --check` exited 0. Log: `.coder-loop/runtime/evidence/issue-103/git-diff-check.log`.
- `ruby -e 'require "yaml"; ...' .github/workflows/ci.yml .github/workflows/deploy.yml` exited 0 and reported both workflow files parse. Log: `.coder-loop/runtime/evidence/issue-103/yaml-parse.log`.
- `act pull_request -W .github/workflows/ci.yml -j ci ... --dryrun` exited 0 and resolved the CI job to `catthehacker/ubuntu:full-24.04` on `platform=linux/amd64`. Log: `.coder-loop/runtime/evidence/issue-103/act-ci-dryrun.log`.
- `act pull_request -W .github/workflows/deploy.yml -j build ... --dryrun` exited 0 and resolved the deploy build job to the same Ubuntu 24.04 job container. Log: `.coder-loop/runtime/evidence/issue-103/act-deploy-build-dryrun.log`.

The dry runs prove the workflow graph no longer asks GARM for `requested_tags=ubuntu-latest` for the issue's core CI/build jobs.

## Layer 2 — Landing checks

- Changed `.github/workflows/ci.yml`: PR CI now runs on `[self-hosted, linux, vctcn]` with `container.image: catthehacker/ubuntu:full-24.04`, plus a same-repository PR guard.
- Changed `.github/workflows/deploy.yml`: deploy build now runs on `[self-hosted, linux, vctcn]` with the same job container; `pull_request` now exercises build without deploy; the production deploy job is skipped for PRs and checks `ssh`, `ssh-keyscan`, and `rsync` before using the deploy key.
- Updated `src/fork-features/trunk-patches.md` for the upstream-owned `ci.yml` runner-stanza patch.
- Local CI-parity command under supported Node 22 exited 0 on macOS arm64:

```bash
mise exec node@22 -- sh -c 'set -e; uname -a; arch; node -v; pnpm -v; pnpm install --frozen-lockfile; pnpm run format:check; pnpm exec tsc --noEmit; pnpm exec vitest run'
```

Evidence: `.coder-loop/runtime/evidence/issue-103/local-ci-parity-node22-rerun.log` shows `node v22.22.3`, `pnpm 10.33.0`, `All matched files use Prettier code style!`, `Test Files 31 passed (31)`, and `Tests 338 passed (338)`.

The same local sequence was also attempted under the host default Node 26 and failed because `better-sqlite3@11.10.0` does not compile against Node 26's V8 API. That host-version drift is recorded in `.coder-loop/runtime/evidence/issue-103/local-ci-parity.log` and `.coder-loop/runtime/evidence/issue-103/pnpm-rebuild-better-sqlite3.log`; it is not the project runtime path because the workflows use Node 20/22.

## Layer 3 — Startup / runtime ordering

- Actual local workflow simulation for CI exited 0:

```bash
act pull_request -W .github/workflows/ci.yml -j ci -e .coder-loop/runtime/evidence/issue-103/pull_request_event.json --container-architecture linux/amd64 -P self-hosted=catthehacker/ubuntu:act-24.04
```

Log: `.coder-loop/runtime/evidence/issue-103/act-ci.log`. Excerpts: `Start image=catthehacker/ubuntu:full-24.04`, `Success - Main Format check`, `Success - Main Typecheck host`, `Success - Main Typecheck container`, host Vitest `31 passed (31)`, container Bun tests `Ran 99 tests across 9 files`, and `Job succeeded`.

- Actual local workflow simulation for the deploy build job exited 0 with an evidence-local artifact server:

```bash
act pull_request -W .github/workflows/deploy.yml -j build -e .coder-loop/runtime/evidence/issue-103/pull_request_event.json --container-architecture linux/amd64 -P self-hosted=catthehacker/ubuntu:act-24.04 --artifact-server-path .coder-loop/runtime/evidence/issue-103/act-artifacts
```

Log: `.coder-loop/runtime/evidence/issue-103/act-deploy-build-artifacts.log`. Excerpts: `Success - Main pnpm install --frozen-lockfile`, `Success - Main pnpm run build`, all five artifacts uploaded (`dist`, `container`, `scripts`, `setup`, `manifest`), and `Job succeeded`.

This verifies the changed job startup order through the same job-container mechanism that will run on the vctcn runner. The production deploy job was not run locally or by PR simulation; it remains gated to non-PR events so PR validation cannot restart NanoClaw.

## Layer 4 — End-to-end behavior

Remote GitHub Actions checks cannot exist until the PR is created. After opening this PR, the iteration will add a PR-thread comment with `gh pr checks`, the remote CI/deploy-build run result, and a GARM log query for NanoClaw `no pools matching` messages. Full production deploy is intentionally not triggered by this PR because `deploy` restarts the live NanoClaw service; the PR path exercises the deploy build job only.

## Analysis

The local workflow evidence covers the routing change that caused the original GARM tag mismatch: both core jobs now request `[self-hosted, linux, vctcn]` and start inside the Ubuntu 24.04 job container instead of requesting `ubuntu-latest`. The evidence also keeps deploy safety intact: PRs run build only, while production deploy keeps its existing host-side runner path and now fails early if `rsync` is unavailable. Remaining acceptance depends on live GitHub/GARM scheduling after PR creation; that remote result will be posted on the PR thread rather than guessed from local simulation.
