### PR TITLE
docs(ci): 指向 runner-canary local-cicd 样板

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
-# Pattern A (per local-cicd §Deployment patterns):
+# Pattern A (per runner-canary local-cicd §Deployment patterns):
 # build on the vctcn runner in an ubuntu-latest-compatible job container,
 # deploy on the netbird-mesh runner.
 # The deploy step rsyncs dist/ + container/ to

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -32,9 +32,9 @@ After this play completes, the VM is parked waiting for the first GitHub Actions
 
 ## Code deploys (every push to `main`)
 
-`.github/workflows/deploy.yml` implements **Pattern A** (build on hosted runner, deploy on a netbird-mesh-attached self-hosted runner). The pattern is the same one used across the operator's other private services and is documented in `Mouriya-Emma/local-cicd-demo`.
+`.github/workflows/deploy.yml` implements **Pattern A** (build on the vctcn self-hosted runner, deploy on a netbird-mesh-attached self-hosted runner). The pattern is the same one used across the operator's other private services and is documented by the current `mouriya-s-lab/runner-canary` local-cicd template.
 
-The build job runs on `ubuntu-latest`, does `npm ci && npm run build`, and uploads four artifacts: `dist/`, `container/`, `scripts/`, and the `package.json` + `package-lock.json` pair. The deploy job runs on `[self-hosted, linux, vctcn]` (the netbird-attached runner sitting in OVH; it can reach `nanoclaw.mouriya.lan` over the mesh, GitHub-hosted runners cannot).
+The build job runs on `[self-hosted, linux, vctcn]` in the `catthehacker/ubuntu:full-24.04` job container, does the project-native install/build, and uploads `dist/`, `container/`, `scripts/`, `setup/`, and the pnpm manifest trio. The deploy job also runs on `[self-hosted, linux, vctcn]` (the netbird-attached runner sitting in OVH; it can reach `nanoclaw.mouriya.lan` over the mesh, GitHub-hosted runners cannot).
 
 The deploy job:
 


### PR DESCRIPTION
Closes #108

## 摘要

把 NanoClaw deploy workflow 注释和部署文档从旧 `local-cicd-demo` 改成当前 `runner-canary` local-cicd 样板，并修正文档中 build runner 的描述。

## 变更预演（Layer 1）

不适用——文档/注释变更，无声明式 dry-run target。

## 落地核对（Layer 2）

```text
git diff --check
yq e . .github/workflows/deploy.yml >/dev/null
grep -R "local-cicd-demo" .github/workflows/deploy.yml docs/DEPLOYMENT.md; test $? -eq 1
```

分析：workflow YAML 可解析，旧样板引用已移除。

## 启动 / 运行时顺序（Layer 3）

不适用——只改文档和 workflow 注释，不改变 CI 执行顺序。

## 端到端业务行为（Layer 4）

```text
ssh root@vctcn-runner.mouriya.lan "docker exec garm garm-cli --format json pool show 7249575a-4cba-45ad-b9d1-4668cabbaf00"
# observed: mouriya-s-lab/nanoclaw flavor=docker labels=linux,netbird,self-hosted,vctcn,x64 min_idle=0 timeout=60
```

分析：文档描述的 vctcn self-hosted path 与 live NanoClaw pool 一致。

## Analysis

PR 只修正维护入口，不改部署行为；当前文档不会再误导读者去找旧样板仓或 hosted build 路径。缺少这项会让后续 local-cicd 修复继续从 stale 文档出发。