### PR TITLE
ci(deploy): 使用 GARM 已预热 job container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,6 @@ jobs:
   build:
     if: github.repository == 'mouriya-s-lab/nanoclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, linux, vctcn]
-    container:
-      image: catthehacker/ubuntu:act-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
     if: github.repository == 'mouriya-s-lab/nanoclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [self-hosted, linux, vctcn]
     container:
-      image: catthehacker/ubuntu:full-24.04
+      image: catthehacker/ubuntu:act-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Closes #110

## 摘要

移除 NanoClaw `deploy` workflow build job 的 Docker job container，让 checkout / pnpm build 直接跑在 vctcn GARM LXD runner host 上，避免真实 run 卡在 job container 初始化或容器内 checkout。

## 变更预演（Layer 1）

不适用——纯 workflow YAML 变更，没有声明式 dry-run target。证据从 Layer 2 开始。

## 落地核对（Layer 2）

```text
$ yq e . .github/workflows/deploy.yml >/dev/null
# exit 0
$ git diff --check
# exit 0
$ sed -n '52,62p' .github/workflows/deploy.yml
jobs:
  build:
    if: github.repository == 'mouriya-s-lab/nanoclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
    runs-on: [self-hosted, linux, vctcn]
    steps:
      - uses: actions/checkout@v4
```

本地 YAML 解析通过，且 build job 已不再声明 Docker job container；这会避开 `Initialize containers` 和容器内 DNS/checkout 这两类真实 GARM 卡点。

## 启动 / 运行时顺序（Layer 3）

待合并后用 `deploy.yml` 的真实 `workflow_dispatch` 验证；PR 本身只改 workflow 文件，启动顺序证据必须来自 GitHub Actions 上的 vctcn GARM runner。

## 端到端业务行为（Layer 4）

待合并后运行 `gh workflow run deploy.yml -R mouriya-s-lab/nanoclaw --ref main`，要求 workflow 不再停在 `Initialize containers` / `actions/checkout@v4`，并完成 deploy job 内置 `Restart + smoke`。

## Analysis

真实 run `26713433165` 卡在 job container 初始化，改成预热镜像后 PR run 能进入 checkout，但仍暴露容器层网络不稳定；因此最终修复是移除 build job container，让 workflow 直接使用 GARM runner host。静态验证只能证明 YAML 正确，最终是否满足 #110 仍以合并后的真实 GARM deploy run 为准。